### PR TITLE
fix: read keys from store before rotating to alleviate desync between instances

### DIFF
--- a/src/main/kotlin/io/nais/security/oauth2/keystore/RotatableKeys.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/keystore/RotatableKeys.kt
@@ -2,6 +2,7 @@ package io.nais.security.oauth2.keystore
 
 import com.nimbusds.jose.jwk.RSAKey
 import io.nais.security.oauth2.utils.generateRsaKey
+import java.time.Duration
 import java.time.LocalDateTime
 
 data class RotatableKeys(
@@ -10,15 +11,26 @@ data class RotatableKeys(
     val nextKey: RSAKey,
     val expiry: LocalDateTime
 ) {
-    fun rotate(expiry: LocalDateTime): RotatableKeys {
+    fun rotate(expiresIn: Duration): RotatableKeys {
         val newKey = generateRsaKey()
         return RotatableKeys(
             previousKey = this.currentKey,
             currentKey = this.nextKey,
             nextKey = newKey,
-            expiry = expiry
+            expiry = LocalDateTime.now().plus(expiresIn)
         )
     }
 
     fun expired(now: LocalDateTime = LocalDateTime.now()) = now.isAfter(this.expiry)
+
+    fun notExpired(now: LocalDateTime = LocalDateTime.now()) = !expired(now)
+
+    companion object {
+        fun generate(expiresIn: Duration): RotatableKeys = RotatableKeys(
+            currentKey = generateRsaKey(),
+            previousKey = generateRsaKey(),
+            nextKey = generateRsaKey(),
+            expiry = LocalDateTime.now().plus(expiresIn)
+        )
+    }
 }

--- a/src/main/kotlin/io/nais/security/oauth2/keystore/RotatingKeyStore.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/keystore/RotatingKeyStore.kt
@@ -7,61 +7,69 @@ import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jose.jwk.source.JWKSource
 import com.nimbusds.jose.proc.SecurityContext
 import io.nais.security.oauth2.config.KeyStoreProperties
-import io.nais.security.oauth2.utils.generateRsaKey
 import mu.KotlinLogging
 import org.slf4j.Logger
 import java.time.Duration
-import java.time.LocalDateTime
 
 private val log: Logger = KotlinLogging.logger { }
 
 class RotatingKeyStore(keyStoreProperties: KeyStoreProperties) : JWKSource<SecurityContext?> {
     private val keyStore: KeyStore = KeyStore(keyStoreProperties.dataSource)
     private val rotationInterval: Duration = keyStoreProperties.rotationInterval
-    private var rotatableKeys: RotatableKeys = keyStore.read() ?: saveGeneratedRsaKeys()
+    private var rotatableKeys: RotatableKeys = getOrGenerateKeys()
 
     fun currentSigningKey(): RSAKey {
-        return getAndRotateKeys(rotationInterval).currentKey
+        return getAndRotateKeysIfExpired().currentKey
     }
 
     val publicJWKSet: JWKSet
         get() {
-            val keys = getAndRotateKeys(rotationInterval)
+            val keys: RotatableKeys = getAndRotateKeysIfExpired()
             val jwkList: MutableList<JWK> = ArrayList()
             jwkList.add(keys.currentKey)
             jwkList.add(keys.previousKey)
             return JWKSet(jwkList).toPublicJWKSet()
         }
 
-    private fun getAndRotateKeys(rotationInterval: Duration): RotatableKeys {
-        log.debug("check keys for expiry and rotate if neccessary")
+    private fun getAndRotateKeysIfExpired(): RotatableKeys {
+        log.debug("checking keys for expiry and rotating if necessary")
         if (rotatableKeys.expired()) {
-            keyStore.read()?.let { current ->
-                rotatableKeys = current
-                if (current.expired()) {
-                    val expiry = LocalDateTime.now().plus(rotationInterval)
-                    rotatableKeys = current.rotate(expiry).also {
-                        keyStore.save(it)
-                        log.info("Keys rotated, next expiry: $expiry")
-                    }
-                }
-            } ?: throw RuntimeException("Could not get current keys from storage")
+            rotatableKeys = getOrGenerateKeys()
         }
         return rotatableKeys
+    }
+
+    private fun getOrGenerateKeys(): RotatableKeys {
+        val keys: RotatableKeys = keyStore.read() ?: generateKeysAndSave()
+        if (keys.notExpired()) {
+            return keys
+        }
+        return rotateKeysAndSave(keys)
+    }
+
+    private fun generateKeysAndSave(): RotatableKeys =
+        RotatableKeys
+            .generate(expiresIn = rotationInterval)
+            .saveToKeyStore()
+            .also { log.info("No previous key set found. Initialised new key set, next expiry: ${it.expiry}") }
+
+    private fun rotateKeysAndSave(keys: RotatableKeys): RotatableKeys =
+        keys.rotate(expiresIn = rotationInterval)
+            .saveToKeyStore()
+            .also { log.info("Keys rotated, next expiry: ${it.expiry}") }
+
+    private fun RotatableKeys.saveToKeyStore(): RotatableKeys {
+        // lookup keys one last time before upserting
+        keyStore.read()?.let { keys ->
+            if (keys.notExpired()) {
+                return keys
+            }
+        }
+        keyStore.save(this)
+        return this
     }
 
     override fun get(jwkSelector: JWKSelector?, context: SecurityContext?): List<JWK> {
         return publicJWKSet.keys
     }
-
-    private fun saveGeneratedRsaKeys(): RotatableKeys =
-        RotatableKeys(
-            currentKey = generateRsaKey(),
-            previousKey = generateRsaKey(),
-            nextKey = generateRsaKey(),
-            expiry = LocalDateTime.now().plus(rotationInterval)
-        ).also {
-            keyStore.save(it)
-            log.info("RSA KEY initialised, next expiry: ${it.expiry}")
-        }
 }

--- a/src/main/kotlin/io/nais/security/oauth2/token/TokenIssuer.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/token/TokenIssuer.kt
@@ -29,7 +29,7 @@ class TokenIssuer(authorizationServerProperties: AuthorizationServerProperties) 
 
     private val internalTokenValidator: TokenValidator = TokenValidator(issuerUrl, rotatingKeyStore)
 
-    fun publicJwkSet(): JWKSet = rotatingKeyStore.publicJWKSet
+    fun publicJwkSet(): JWKSet = rotatingKeyStore.publicJWKSet()
 
     fun issueTokenFor(oAuth2Client: OAuth2Client, tokenExchangeRequest: OAuth2TokenExchangeRequest): SignedJWT {
         val targetAudience: String = tokenExchangeRequest.audience

--- a/src/test/kotlin/io/nais/security/oauth2/keystore/RotatableKeysTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/keystore/RotatableKeysTest.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.nais.security.oauth2.utils.generateRsaKey
 import org.junit.jupiter.api.Test
+import java.time.Duration
 import java.time.LocalDateTime
 
 internal class RotatableKeysTest {
@@ -17,7 +18,7 @@ internal class RotatableKeysTest {
             nextKey = generateRsaKey(),
             expiry = expiry
         )
-        val rotated = initial.rotate(expiry.plusDays(1))
+        val rotated = initial.rotate(Duration.ofDays(1))
         rotated.previousKey shouldBe initial.currentKey
         rotated.currentKey shouldBe initial.nextKey
         rotated.nextKey shouldNotBe initial.nextKey

--- a/src/test/kotlin/io/nais/security/oauth2/keystore/RotatingKeyStoreTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/keystore/RotatingKeyStoreTest.kt
@@ -42,13 +42,13 @@ class RotatingKeyStoreTest {
     fun `jwks endpoint should return current and previous key in public format`() {
         withMigratedDb {
             with(rotatingKeyStore()) {
-                val currentPublicKey = this.publicJWKSet.keys[0]
-                val previousPublicKey = this.publicJWKSet.keys[1]
+                val currentPublicKey = this.publicJWKSet().keys[0]
+                val previousPublicKey = this.publicJWKSet().keys[1]
                 currentPublicKey.isPrivate shouldBe false
                 previousPublicKey.isPrivate shouldBe false
-                this.publicJWKSet.keys.size shouldBe 2
-                this.publicJWKSet.keys[0] shouldBe currentPublicKey
-                this.publicJWKSet.keys[1] shouldBe previousPublicKey
+                this.publicJWKSet().keys.size shouldBe 2
+                this.publicJWKSet().keys[0] shouldBe currentPublicKey
+                this.publicJWKSet().keys[1] shouldBe previousPublicKey
             }
         }
     }
@@ -69,8 +69,8 @@ class RotatingKeyStoreTest {
                     service.submit {
                         try {
                             val rotatedKey = currentSigningKey()
-                            publicJWKSet.containsJWK(rotatedKey) shouldBe true
-                            publicJWKSet.containsJWK(initialKey) shouldBe true
+                            publicJWKSet().containsJWK(rotatedKey) shouldBe true
+                            publicJWKSet().containsJWK(initialKey) shouldBe true
                         } finally {
                             latch.countDown()
                         }


### PR DESCRIPTION
fix: i think we removed to much when we were refactoring. Currently the implementation only checks db at start up and never again, that could explain the issue with different signingkeys (current) but same previous key.