### PR TITLE
fix: removes the @KtorExperimentalAPI from every module.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val assertjVersion = "3.19.0"
 val flywayVersion = "7.12.0"
@@ -10,7 +11,7 @@ val kotestVersion = "4.6.1"
 val kotlinLoggingVersion = "2.0.10"
 val kotlinVersion = "1.5.21"
 val kotliqueryVersion = "1.3.1"
-val ktorVersion = "1.5.2"
+val ktorVersion = "1.6.2"
 val logbackVersion = "1.2.5"
 val logstashLogbackEncoderVersion = "6.6"
 val micrometerRegistryPrometheusVersion = "1.7.2"
@@ -102,9 +103,14 @@ tasks {
         }
     }
 
-    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    withType<KotlinCompile> {
         kotlinOptions {
             jvmTarget = "15"
+            configureEach {
+                freeCompilerArgs = listOf(
+                    "-Xopt-in=io.ktor.util.KtorExperimentalAPI"
+                )
+            }
         }
     }
 

--- a/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
@@ -39,7 +39,6 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.engine.stop
 import io.ktor.server.netty.Netty
 import io.ktor.server.netty.NettyApplicationEngine
-import io.ktor.util.KtorExperimentalAPI
 import io.micrometer.core.instrument.Clock
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
@@ -67,7 +66,6 @@ import kotlin.system.exitProcess
 
 private val log = KotlinLogging.logger { }
 
-@KtorExperimentalAPI
 fun main() {
     try {
         val engine = server()
@@ -81,7 +79,6 @@ fun main() {
     }
 }
 
-@KtorExperimentalAPI
 fun server(): NettyApplicationEngine =
     embeddedServer(
         Netty,
@@ -96,7 +93,6 @@ fun server(): NettyApplicationEngine =
         }
     )
 
-@KtorExperimentalAPI
 fun Application.tokenExchangeApp(config: AppConfiguration, routing: ApiRouting) {
     install(CallId) {
         header(HttpHeaders.XCorrelationId)
@@ -152,7 +148,6 @@ fun Application.tokenExchangeApp(config: AppConfiguration, routing: ApiRouting) 
     }
 }
 
-@KtorExperimentalAPI
 fun StatusPages.Configuration.installExceptionHandling(config: AppConfiguration) = exception<Throwable> { cause ->
     log.error("request failed: $cause", cause)
     when (cause) {
@@ -196,7 +191,6 @@ private fun ErrorObject.toGeneric(): ErrorObject =
         this.uri
     )
 
-@KtorExperimentalAPI
 internal val defaultHttpClient = HttpClient(CIO) {
     install(JsonFeature) {
         serializer = JacksonSerializer {

--- a/src/main/kotlin/io/nais/security/oauth2/authentication/BearerTokenAuthenticationConfiguration.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/authentication/BearerTokenAuthenticationConfiguration.kt
@@ -11,7 +11,6 @@ import io.ktor.auth.Authentication
 import io.ktor.auth.jwt.JWTPrincipal
 import io.ktor.auth.jwt.jwt
 import io.ktor.http.auth.HttpAuthHeader
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.authentication.BearerTokenAuth.CLIENT_REGISTRATION_AUTH
 import io.nais.security.oauth2.config.AppConfiguration
 import io.nais.security.oauth2.config.ClientRegistrationAuthProperties
@@ -32,7 +31,6 @@ object BearerTokenAuth {
     val ACCEPTED_ROLES_CLAIM_VALUE = listOf("access_as_application")
 }
 
-@KtorExperimentalAPI
 fun Authentication.Configuration.clientRegistrationAuth(appConfig: AppConfiguration) {
     jwt(CLIENT_REGISTRATION_AUTH) {
         val properties = appConfig.clientRegistrationAuthProperties
@@ -78,7 +76,6 @@ fun Authentication.Configuration.clientRegistrationAuth(appConfig: AppConfigurat
     }
 }
 
-@KtorExperimentalAPI
 internal fun bearerTokenVerifier(
     jwkProvider: JwkProvider,
     properties: ClientRegistrationAuthProperties,

--- a/src/main/kotlin/io/nais/security/oauth2/config/AppConfiguration.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/config/AppConfiguration.kt
@@ -5,7 +5,6 @@ import com.auth0.jwk.JwkProviderBuilder
 import com.nimbusds.jose.jwk.JWKSet
 import com.zaxxer.hikari.HikariDataSource
 import io.ktor.client.request.get
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.authentication.BearerTokenAuth
 import io.nais.security.oauth2.config.JwkCache.BUCKET_SIZE
 import io.nais.security.oauth2.config.JwkCache.CACHE_SIZE
@@ -34,7 +33,6 @@ object JwkCache {
     const val BUCKET_SIZE = 10L
 }
 
-@KtorExperimentalAPI
 data class AppConfiguration(
     val serverProperties: ServerProperties,
     val clientRegistry: ClientRegistry,
@@ -51,7 +49,6 @@ data class ClientRegistryProperties(
     val dataSource: DataSource
 )
 
-@KtorExperimentalAPI
 data class ClientRegistrationAuthProperties(
     val identityProviderWellKnownUrl: String,
     val acceptedAudience: List<String>,
@@ -68,7 +65,6 @@ data class ClientRegistrationAuthProperties(
         .build()
 }
 
-@KtorExperimentalAPI
 class AuthorizationServerProperties(
     val issuerUrl: String,
     val subjectTokenIssuers: List<SubjectTokenIssuer>,
@@ -88,7 +84,6 @@ class AuthorizationServerProperties(
     }
 }
 
-@KtorExperimentalAPI
 class SubjectTokenIssuer(private val wellKnownUrl: String) {
     val wellKnown: WellKnown = runBlocking {
         log.info("getting OAuth2 server metadata from well-known url=$wellKnownUrl")

--- a/src/main/kotlin/io/nais/security/oauth2/config/EnvConfiguration.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/config/EnvConfiguration.kt
@@ -8,7 +8,6 @@ import com.natpryce.konfig.listType
 import com.natpryce.konfig.overriding
 import com.natpryce.konfig.stringType
 import com.nimbusds.jose.jwk.JWKSet
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.authentication.BearerTokenAuth
 import io.nais.security.oauth2.config.EnvKey.APPLICATION_PORT
 import io.nais.security.oauth2.config.EnvKey.APPLICATION_PROFILE
@@ -41,7 +40,6 @@ internal object EnvKey {
     const val APPLICATION_PORT = 8080
 }
 
-@KtorExperimentalAPI
 object ProdConfiguration {
     private const val issuerUrl = "https://tokendings.prod-gcp.nais.io"
     private val subjectTokenIssuers = listOf(
@@ -72,7 +70,6 @@ object ProdConfiguration {
     }
 }
 
-@KtorExperimentalAPI
 object NonProdConfiguration {
     private const val issuerUrl = "https://tokendings.dev-gcp.nais.io"
     private val subjectTokenIssuers = listOf(
@@ -104,12 +101,10 @@ object NonProdConfiguration {
     }
 }
 
-@KtorExperimentalAPI
 fun List<String>.toConfiguration() = this.map { issuerWellKnown ->
     SubjectTokenIssuer(issuerWellKnown)
 }
 
-@KtorExperimentalAPI
 fun configByProfile(): AppConfiguration =
     when (konfig.getOrNull(Key(APPLICATION_PROFILE, enumType<Profile>()))) {
         Profile.NON_PROD -> NonProdConfiguration.instance
@@ -118,7 +113,6 @@ fun configByProfile(): AppConfiguration =
     }
 
 @Suppress("unused")
-@KtorExperimentalAPI
 fun AppConfiguration.isNonProd() = Profile.PROD != konfig.getOrNull(Key(APPLICATION_PROFILE, enumType<Profile>()))
 
 internal fun databaseConfig(): DatabaseConfig {
@@ -132,7 +126,6 @@ internal fun databaseConfig(): DatabaseConfig {
     )
 }
 
-@KtorExperimentalAPI
 internal fun clientRegistrationAuthProperties(): ClientRegistrationAuthProperties =
     ClientRegistrationAuthProperties(
         identityProviderWellKnownUrl =

--- a/src/main/kotlin/io/nais/security/oauth2/routing/ClientRegistrationApi.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/routing/ClientRegistrationApi.kt
@@ -11,7 +11,6 @@ import io.ktor.routing.delete
 import io.ktor.routing.get
 import io.ktor.routing.post
 import io.ktor.routing.route
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.authentication.BearerTokenAuth
 import io.nais.security.oauth2.config.AppConfiguration
 import io.nais.security.oauth2.model.AccessPolicy
@@ -22,7 +21,6 @@ import io.nais.security.oauth2.model.OAuth2Client
 import io.nais.security.oauth2.model.OAuth2Exception
 import io.nais.security.oauth2.model.verifySoftwareStatement
 
-@KtorExperimentalAPI
 internal fun Route.clientRegistrationApi(config: AppConfiguration) {
     authenticate(BearerTokenAuth.CLIENT_REGISTRATION_AUTH) {
         route("/registration/client") {

--- a/src/main/kotlin/io/nais/security/oauth2/routing/DefaultRouting.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/routing/DefaultRouting.kt
@@ -3,14 +3,12 @@ package io.nais.security.oauth2.routing
 import io.ktor.application.Application
 import io.ktor.routing.Routing
 import io.ktor.routing.routing
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.config.AppConfiguration
 
 interface ApiRouting {
     fun apiRouting(application: Application): Routing
 }
 
-@KtorExperimentalAPI
 open class DefaultRouting(private val config: AppConfiguration) : ApiRouting {
     override fun apiRouting(application: Application): Routing =
         application.routing {

--- a/src/main/kotlin/io/nais/security/oauth2/routing/TokenExchangeApi.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/routing/TokenExchangeApi.kt
@@ -8,7 +8,6 @@ import io.ktor.routing.Routing
 import io.ktor.routing.get
 import io.ktor.routing.post
 import io.ktor.routing.route
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.authentication.TokenExchangeRequestAuthorizer
 import io.nais.security.oauth2.authentication.receiveTokenRequestContext
 import io.nais.security.oauth2.config.AppConfiguration
@@ -27,7 +26,6 @@ import mu.KotlinLogging
 
 private val log = KotlinLogging.logger { }
 
-@KtorExperimentalAPI
 internal fun Routing.tokenExchangeApi(config: AppConfiguration) {
     val tokenIssuer = config.tokenIssuer
 

--- a/src/main/kotlin/io/nais/security/oauth2/token/TokenIssuer.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/token/TokenIssuer.kt
@@ -4,7 +4,6 @@ import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.OAuth2Error
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.config.AuthorizationServerProperties
 import io.nais.security.oauth2.keystore.RotatingKeyStore
 import io.nais.security.oauth2.model.OAuth2Client
@@ -16,7 +15,6 @@ import java.time.Instant
 import java.util.Date
 import java.util.UUID
 
-@KtorExperimentalAPI
 class TokenIssuer(authorizationServerProperties: AuthorizationServerProperties) {
 
     private val issuerUrl: String = authorizationServerProperties.issuerUrl

--- a/src/test/kotlin/io/nais/security/oauth2/mock/MockConfiguration.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/mock/MockConfiguration.kt
@@ -3,7 +3,6 @@ package io.nais.security.oauth2.mock
 import com.auth0.jwk.JwkProvider
 import com.zaxxer.hikari.HikariDataSource
 import io.ktor.application.Application
-import io.ktor.util.KtorExperimentalAPI
 import io.mockk.every
 import io.mockk.mockk
 import io.nais.security.oauth2.authentication.BearerTokenAuth
@@ -31,7 +30,6 @@ import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.testcontainers.containers.PostgreSQLContainer
 import java.time.Duration
 
-@KtorExperimentalAPI
 fun mockConfig(
     mockOAuth2Server: MockOAuth2Server? = null,
     clientRegistrationAuthProperties: ClientRegistrationAuthProperties? = null,
@@ -70,7 +68,6 @@ fun mockConfig(
     )
 }
 
-@KtorExperimentalAPI
 fun mockBearerTokenAuthenticationProperties(): ClientRegistrationAuthProperties =
     mockBearerTokenAuthenticationProperties(
         mockk<WellKnown>().also {
@@ -80,7 +77,6 @@ fun mockBearerTokenAuthenticationProperties(): ClientRegistrationAuthProperties 
         mockk()
     )
 
-@KtorExperimentalAPI
 fun mockBearerTokenAuthenticationProperties(wellKnown: WellKnown, jwkProvider: JwkProvider): ClientRegistrationAuthProperties =
     mockk<ClientRegistrationAuthProperties>().also {
         every { it.wellKnown } returns wellKnown
@@ -91,7 +87,6 @@ fun rotatingKeyStore(): RotatingKeyStore = MockRotatingKeyStore()
 
 fun rotatingKeyStore(rotationInterval: Duration): RotatingKeyStore = MockRotatingKeyStore(rotationInterval)
 
-@KtorExperimentalAPI
 fun MockApp(
     config: AppConfiguration = mockConfig()
 ): Application.() -> Unit {

--- a/src/test/kotlin/io/nais/security/oauth2/mock/MockJwkerApp.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/mock/MockJwkerApp.kt
@@ -43,7 +43,6 @@ import io.ktor.server.engine.applicationEngineEnvironment
 import io.ktor.server.engine.connector
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.Jackson
 import io.nais.security.oauth2.model.ClientRegistration
 import io.nais.security.oauth2.model.ClientRegistrationRequest
@@ -69,7 +68,6 @@ data class ClientConfig(
     }
 )
 
-@KtorExperimentalAPI
 fun main() {
     embeddedServer(
         Netty,
@@ -84,7 +82,6 @@ fun main() {
     ).start()
 }
 
-@KtorExperimentalAPI
 fun Application.mockJwkerApp() {
     val tokenDingsClient = TokenDingsClient()
 
@@ -141,7 +138,6 @@ fun Application.mockJwkerApp() {
     }
 }
 
-@KtorExperimentalAPI
 class TokenDingsClient(private val config: ClientConfig = ClientConfig()) {
 
     suspend fun registerClient(
@@ -247,7 +243,6 @@ private fun createClientAssertion(clientId: String, tokenEndpoint: String, rsaKe
         sign(RSASSASigner(rsaKey.toPrivateKey()))
     }.serialize()
 
-@KtorExperimentalAPI
 internal val httpClient = HttpClient(CIO) {
     install(JsonFeature) {
         serializer = JacksonSerializer {

--- a/src/test/kotlin/io/nais/security/oauth2/mock/MockTokenExchangeApp.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/mock/MockTokenExchangeApp.kt
@@ -5,7 +5,6 @@ import io.ktor.server.engine.applicationEngineEnvironment
 import io.ktor.server.engine.connector
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.authentication.BearerTokenAuth
 import io.nais.security.oauth2.config.AppConfiguration
 import io.nais.security.oauth2.config.ClientRegistrationAuthProperties
@@ -22,7 +21,6 @@ private val jwkerJwks = "jwker-jwks.json".asResource().readText().let {
     JWKSet.parse(it)
 }
 
-@KtorExperimentalAPI
 fun main() {
     val mockOAuth2Server: MockOAuth2Server = startMockOAuth2Server()
 

--- a/src/test/kotlin/io/nais/security/oauth2/routing/ClientRegistrationApiTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/routing/ClientRegistrationApiTest.kt
@@ -12,7 +12,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.authentication.BearerTokenAuth
 import io.nais.security.oauth2.config.ClientRegistrationAuthProperties
 import io.nais.security.oauth2.mock.MockApp
@@ -33,7 +32,6 @@ import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
-@KtorExperimentalAPI
 internal class ClientRegistrationApiTest {
 
     @AfterEach

--- a/src/test/kotlin/io/nais/security/oauth2/routing/ObservabilityApiTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/routing/ObservabilityApiTest.kt
@@ -5,7 +5,6 @@ import io.ktor.http.HttpStatusCode.Companion.InternalServerError
 import io.ktor.http.HttpStatusCode.Companion.OK
 import io.ktor.server.testing.withTestApplication
 import io.ktor.server.testing.handleRequest
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.mock.mockConfig
 import io.nais.security.oauth2.mock.withMockOAuth2Server
 import io.nais.security.oauth2.tokenExchangeApp
@@ -14,7 +13,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
-@KtorExperimentalAPI
 internal class ObservabilityApiTest {
 
     @Test

--- a/src/test/kotlin/io/nais/security/oauth2/routing/TokenExchangeApiTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/routing/TokenExchangeApiTest.kt
@@ -15,7 +15,6 @@ import io.ktor.http.formUrlEncode
 import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.Jackson
 import io.nais.security.oauth2.config.AppConfiguration
 import io.nais.security.oauth2.config.AuthorizationServerProperties.Companion.jwksPath
@@ -43,7 +42,6 @@ import java.time.Instant
 import java.util.Date
 import java.util.UUID
 
-@KtorExperimentalAPI
 internal class TokenExchangeApiTest {
     private val mapper = Jackson.defaultMapper
 

--- a/src/test/kotlin/io/nais/security/oauth2/token/TokenIssuerTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/token/TokenIssuerTest.kt
@@ -2,7 +2,6 @@ package io.nais.security.oauth2.token
 
 import io.kotest.matchers.maps.shouldContainAll
 import io.kotest.matchers.shouldBe
-import io.ktor.util.KtorExperimentalAPI
 import io.nais.security.oauth2.config.AuthorizationServerProperties
 import io.nais.security.oauth2.config.SubjectTokenIssuer
 import io.nais.security.oauth2.keystore.MockRotatingKeyStore
@@ -21,7 +20,6 @@ import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import org.junit.jupiter.api.Test
 import java.time.Duration
 
-@KtorExperimentalAPI
 internal class TokenIssuerTest {
 
     @Test
@@ -72,7 +70,6 @@ internal class TokenIssuerTest {
 
             with(tokenIssuer(mockOAuth2Server = this, rotatingKeyStore = fakeKeyStore)) {
                 val oAuth2Client = oAuth2Client()
-                val tokenAudience = "jollo"
                 val issuedToken = issueTokenFor(
                     oAuth2Client,
                     tokenExchangeRequest(subjectToken, "aud")


### PR DESCRIPTION
Using the API. Does only suppress warnings, not actually handle em, but the codes dont gt overflowed with @ notations. Updates ktor from 1.5.2 to 1.6.2, fixes waiting dep. from depandanbot PR.