### PR TITLE
feat(token): allow custom mapping of subject token claim values

### DIFF
--- a/src/main/kotlin/io/nais/security/oauth2/model/SubjectTokenMapping.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/model/SubjectTokenMapping.kt
@@ -1,0 +1,15 @@
+package io.nais.security.oauth2.model
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
+typealias IssuerWellKnown = String
+typealias Claim = String
+typealias ClaimValue = String
+
+typealias IssuerClaimMappings = Map<IssuerWellKnown, ClaimMappings>
+typealias ClaimMappings = Map<Claim, ClaimValueMapping>
+typealias ClaimValueMapping = Map<ClaimValue, ClaimValue>
+
+fun issuerClaimMappingsFromJson(json: String): IssuerClaimMappings = jacksonObjectMapper()
+    .readValue<IssuerClaimMappings>(json)

--- a/src/main/kotlin/io/nais/security/oauth2/token/TokenIssuer.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/token/TokenIssuer.kt
@@ -92,6 +92,7 @@ class TokenIssuer(authorizationServerProperties: AuthorizationServerProperties) 
     private fun JWTClaimsSet.Builder.mapSubjectTokenClaims(issuer: String?, subjectTokenClaims: JWTClaimsSet): JWTClaimsSet.Builder {
         val mappings: ClaimMappings = issuer
             ?.let { issuerSubjectTokenMappings[issuer] }
+            ?.takeIf { mapping -> mapping.isNotEmpty() }
             ?: return this
 
         for ((claim, mapping) in mappings) {

--- a/src/test/kotlin/io/nais/security/oauth2/model/SubjectTokenMappingsTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/model/SubjectTokenMappingsTest.kt
@@ -1,0 +1,51 @@
+package io.nais.security.oauth2.model;
+
+import io.kotest.matchers.equals.shouldBeEqual
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test;
+
+internal class SubjectTokenMappingsTest {
+
+    @Test
+    fun `deserialize JSON to list of SubjectTokenMapping`() {
+        @Language("JSON")
+        val json = """
+            {
+                "https://authorization-server/.well-known/openid-configuration": { 
+                    "claim1": {
+                        "claim1value": "newclaim1value",
+                        "claim1othervalue": "newclaim1othervalue"
+                    },
+                    "claim2": {
+                        "claim2value": "newclaim2value"
+                    }
+                },
+                "https://another-authorization-server/.well-known/openid-configuration": {
+                    "claim1": {
+                        "claim1value": "newclaim1value"
+                    }
+                }
+            }
+        """.trimIndent()
+
+        val expected = mapOf(
+            "https://authorization-server/.well-known/openid-configuration" to mapOf(
+                "claim1" to mapOf(
+                    "claim1value" to "newclaim1value",
+                    "claim1othervalue" to "newclaim1othervalue"
+                ),
+                "claim2" to mapOf(
+                    "claim2value" to "newclaim2value",
+                ),
+            ),
+            "https://another-authorization-server/.well-known/openid-configuration" to mapOf(
+                "claim1" to mapOf(
+                    "claim1value" to "newclaim1value",
+                ),
+            )
+        )
+
+        val deserialized: IssuerClaimMappings = issuerClaimMappingsFromJson(json)
+        deserialized shouldBeEqual expected
+    }
+}


### PR DESCRIPTION
Allows for mapping of subject token claims, per issuer.

Restrictions:

- claim value must be of string type
- claim value must exactly match the configured value that we're mapping from

Example config:

```json
{
    "https://authorization-server/.well-known/openid-configuration": { 
        "claim1": {
            "claim1value": "newclaim1value",
            "claim1othervalue": "newclaim1othervalue"
        }
    }
}
```

will only map tokens that contains the claim named `claim1`. The claim value must match exactly either:

- `claimv1value` - which is mapped to `newclaim1value` or
- `claim1othervalue` - which is mapped to`newclaim1othervalue`