### PR TITLE
add(clientStore): try to speed up things

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,7 +18,7 @@ jobs:
       img_to_deploy: ${{ steps.build-push-sign.outputs.tag }}
       version: ${{ steps.build-push-sign.outputs.version }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4

--- a/.github/workflows/test-pull-requests.yml
+++ b/.github/workflows/test-pull-requests.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: "write"
     steps:

--- a/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestAuthorizer.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestAuthorizer.kt
@@ -21,7 +21,7 @@ interface TokenRequestAuthorizer<T : OAuth2TokenRequest> {
 }
 
 class TokenExchangeRequestAuthorizer(
-    private val preloadedClients: Map<String, OAuth2Client>
+    private val targetClients: Map<String, OAuth2Client>
 ) : TokenRequestAuthorizer<OAuth2TokenExchangeRequest> {
 
     override fun supportsGrantType(grantType: String?): Boolean = grantType == GrantType.TOKEN_EXCHANGE_GRANT
@@ -37,7 +37,7 @@ class TokenExchangeRequestAuthorizer(
             parameters["scope"]
         )
 
-        val targetClient = preloadedClients[tokenRequest.audience]
+        val targetClient = targetClients[tokenRequest.audience]
             ?: throw OAuth2Exception(
                 OAuth2Error.INVALID_REQUEST.setDescription(
                     "token exchange audience ${tokenRequest.audience} is invalid"

--- a/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestAuthorizer.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestAuthorizer.kt
@@ -9,7 +9,6 @@ import io.nais.security.oauth2.model.OAuth2Exception
 import io.nais.security.oauth2.model.OAuth2TokenExchangeRequest
 import io.nais.security.oauth2.model.OAuth2TokenRequest
 import io.nais.security.oauth2.model.SubjectTokenType
-import io.nais.security.oauth2.registration.ClientRegistry
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import mu.KotlinLogging
 import org.slf4j.Logger
@@ -22,7 +21,7 @@ interface TokenRequestAuthorizer<T : OAuth2TokenRequest> {
 }
 
 class TokenExchangeRequestAuthorizer(
-    private val clientRegistry: ClientRegistry
+    private val preloadedClients: Map<String, OAuth2Client>
 ) : TokenRequestAuthorizer<OAuth2TokenExchangeRequest> {
 
     override fun supportsGrantType(grantType: String?): Boolean = grantType == GrantType.TOKEN_EXCHANGE_GRANT
@@ -37,15 +36,18 @@ class TokenExchangeRequestAuthorizer(
             parameters["resource"],
             parameters["scope"]
         )
-        val targetClient: OAuth2Client = clientRegistry.findClient(tokenRequest.audience)
+
+        val targetClient = preloadedClients[tokenRequest.audience]
             ?: throw OAuth2Exception(
                 OAuth2Error.INVALID_REQUEST.setDescription(
                     "token exchange audience ${tokenRequest.audience} is invalid"
                 )
             )
-        log.debug("principal: $oauth2Client")
-        val authenticatedClient: OAuth2Client = oauth2Client
-            ?: throw OAuth2Exception(OAuth2Error.INVALID_REQUEST.setDescription("client is not authenticated"))
+
+        val authenticatedClient = oauth2Client
+            ?: throw OAuth2Exception(
+                OAuth2Error.INVALID_REQUEST.setDescription("client is not authenticated")
+            )
 
         return when {
             targetClient.accessPolicyInbound.contains(authenticatedClient.clientId) -> tokenRequest

--- a/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestContext.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestContext.kt
@@ -109,7 +109,6 @@ class TokenRequestConfig internal constructor(
     internal val clientAssertionMaxLifetime = configuration.clientAssertionMaxLifetime
 
     class Configuration {
-        internal lateinit var params: Parameters
         internal var clientFinder: (ClientAssertionCredential) -> OAuth2Client? = {
             throw NotImplementedError("clientFinder function not implemented")
         }

--- a/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestContext.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestContext.kt
@@ -28,17 +28,25 @@ class TokenRequestContext private constructor(
     val oauth2TokenRequest: OAuth2TokenRequest
 ) {
 
+    data class ClientIDs(
+        val client: String,
+        val target: String
+    )
+
     class From(private val tokenEndpointUrl: TokenEndpointUrl, private val parameters: Parameters) {
 
         @WithSpan
         fun authenticateAndAuthorize(
-            configure: TokenRequestConfig.Configuration.() -> Unit
+            configure: TokenRequestConfig.Configuration.(ClientIDs) -> Unit
         ): TokenRequestContext {
-            val config = TokenRequestConfig(TokenRequestConfig.Configuration().apply {
-                this.params = parameters // Set parameters for later use
-                configure()
-            })
             val credential = credential()
+            val config = TokenRequestConfig(TokenRequestConfig.Configuration().apply {
+                val clientIds = ClientIDs(
+                    client = credential.clientId,
+                    target = parameters.require("audience"),
+                )
+                configure(clientIds)
+            })
             val client: OAuth2Client = authenticateClient(config, credential)
             val tokenRequest = authorizeTokenRequest(config, client)
             return TokenRequestContext(client, tokenRequest)
@@ -56,7 +64,7 @@ class TokenRequestContext private constructor(
         private fun authenticateClient(
             config: TokenRequestConfig,
             clientAssertionCredential:
-                ClientAssertionCredential
+            ClientAssertionCredential
         ): OAuth2Client =
             config.clientFinder.invoke(clientAssertionCredential)
                 ?.also { oAuth2Client ->

--- a/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestContext.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestContext.kt
@@ -31,8 +31,13 @@ class TokenRequestContext private constructor(
     class From(private val tokenEndpointUrl: TokenEndpointUrl, private val parameters: Parameters) {
 
         @WithSpan
-        fun authenticateAndAuthorize(configure: TokenRequestConfig.Configuration.() -> Unit): TokenRequestContext {
-            val config = TokenRequestConfig(TokenRequestConfig.Configuration().apply(configure))
+        fun authenticateAndAuthorize(
+            configure: TokenRequestConfig.Configuration.() -> Unit
+        ): TokenRequestContext {
+            val config = TokenRequestConfig(TokenRequestConfig.Configuration().apply {
+                this.params = parameters // Set parameters for later use
+                configure()
+            })
             val credential = credential()
             val client: OAuth2Client = authenticateClient(config, credential)
             val tokenRequest = authorizeTokenRequest(config, client)
@@ -96,6 +101,7 @@ class TokenRequestConfig internal constructor(
     internal val clientAssertionMaxLifetime = configuration.clientAssertionMaxLifetime
 
     class Configuration {
+        internal lateinit var params: Parameters
         internal var clientFinder: (ClientAssertionCredential) -> OAuth2Client? = {
             throw NotImplementedError("clientFinder function not implemented")
         }

--- a/src/main/kotlin/io/nais/security/oauth2/config/AppConfiguration.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/config/AppConfiguration.kt
@@ -26,7 +26,7 @@ import io.nais.security.oauth2.retryingHttpClient
 import io.nais.security.oauth2.token.TokenIssuer
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
-import java.net.URL
+import java.net.URI
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import javax.sql.DataSource
@@ -89,7 +89,7 @@ class AuthProvider(
                 log.info("getting OpenID Connect server metadata from well-known url=$wellKnownUrl")
                 retryingHttpClient.get(wellKnownUrl).body()
             }
-            val jwk = JwkProviderBuilder(URL(wellKnown.jwksUri))
+            val jwk = JwkProviderBuilder(URI(wellKnown.jwksUri).toURL())
                 .cached(CACHE_SIZE, EXPIRES_IN, TimeUnit.HOURS)
                 .rateLimited(BUCKET_SIZE, 1, TimeUnit.MINUTES)
                 .build()
@@ -137,7 +137,7 @@ class SubjectTokenIssuer(private val wellKnownUrl: String, val subjectTokenClaim
     val issuer = wellKnown.issuer
     val cacheProperties = CacheProperties(
         timeToLive = 6.hours,
-        jwksURL = URL(wellKnown.jwksUri),
+        jwksURL = URI(wellKnown.jwksUri).toURL(),
         connectionTimeout = 5.seconds,
         readTimeout = 5.seconds,
         refreshAheadTime = 1.hours,

--- a/src/main/kotlin/io/nais/security/oauth2/registration/ClientRegistry.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/registration/ClientRegistry.kt
@@ -9,6 +9,8 @@ interface ClientRegistry {
     @WithSpan
     fun findClient(@SpanAttribute clientId: ClientId): OAuth2Client?
 
+    fun findClients(@SpanAttribute clientIds: List<String>): Map<String, OAuth2Client>
+
     fun registerClient(client: OAuth2Client): OAuth2Client
 
     fun findAll(): List<OAuth2Client>

--- a/src/main/kotlin/io/nais/security/oauth2/registration/ClientRegistry.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/registration/ClientRegistry.kt
@@ -9,7 +9,8 @@ interface ClientRegistry {
     @WithSpan
     fun findClient(@SpanAttribute clientId: ClientId): OAuth2Client?
 
-    fun findClients(@SpanAttribute clientIds: List<String>): Map<String, OAuth2Client>
+    @WithSpan
+    fun findClients(@SpanAttribute clientIDs: List<String>): Map<String, OAuth2Client>
 
     fun registerClient(client: OAuth2Client): OAuth2Client
 

--- a/src/main/kotlin/io/nais/security/oauth2/registration/ClientRegistryPostgres.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/registration/ClientRegistryPostgres.kt
@@ -14,6 +14,8 @@ open class ClientRegistryPostgres(
 
     override fun findClient(clientId: ClientId): OAuth2Client? = clientStore.find(clientId)
 
+    override fun findClients(clientIds: List<ClientId>) = clientStore.findClients(clientIds)
+
     override fun registerClient(client: OAuth2Client): OAuth2Client {
         log.info("register client with clientId=${client.clientId} and keyIds=${client.jwkSet.keys.map { it.keyID }.toList()}")
         clientStore.storeClient(client)

--- a/src/main/kotlin/io/nais/security/oauth2/registration/ClientRegistryPostgres.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/registration/ClientRegistryPostgres.kt
@@ -14,7 +14,7 @@ open class ClientRegistryPostgres(
 
     override fun findClient(clientId: ClientId): OAuth2Client? = clientStore.find(clientId)
 
-    override fun findClients(clientIds: List<ClientId>) = clientStore.findClients(clientIds)
+    override fun findClients(clientIDs: List<String>) = clientStore.findClients(clientIDs)
 
     override fun registerClient(client: OAuth2Client): OAuth2Client {
         log.info("register client with clientId=${client.clientId} and keyIds=${client.jwkSet.keys.map { it.keyID }.toList()}")

--- a/src/test/kotlin/io/nais/security/oauth2/mock/MockConfiguration.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/mock/MockConfiguration.kt
@@ -98,6 +98,9 @@ class MockClientRegistry : ClientRegistry {
 
     override fun findClient(clientId: ClientId): OAuth2Client? = clients[clientId]
 
+    override fun findClients(clientIds: List<ClientId>): Map<ClientId, OAuth2Client> =
+        clients.filterKeys { it in clientIds }
+
     override fun registerClient(client: OAuth2Client) = client.apply { clients[clientId] = this }
 
     override fun findAll(): List<OAuth2Client> = clients.values.toList()

--- a/src/test/kotlin/io/nais/security/oauth2/mock/MockConfiguration.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/mock/MockConfiguration.kt
@@ -98,8 +98,8 @@ class MockClientRegistry : ClientRegistry {
 
     override fun findClient(clientId: ClientId): OAuth2Client? = clients[clientId]
 
-    override fun findClients(clientIds: List<ClientId>): Map<ClientId, OAuth2Client> =
-        clients.filterKeys { it in clientIds }
+    override fun findClients(clientIDs: List<ClientId>): Map<ClientId, OAuth2Client> =
+        clients.filterKeys { it in clientIDs }
 
     override fun registerClient(client: OAuth2Client) = client.apply { clients[clientId] = this }
 

--- a/src/test/kotlin/io/nais/security/oauth2/registration/ClientStoreTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/registration/ClientStoreTest.kt
@@ -9,6 +9,7 @@ import io.nais.security.oauth2.model.JsonWebKeys
 import io.nais.security.oauth2.model.OAuth2Client
 import io.nais.security.oauth2.utils.jwkSet
 import org.junit.jupiter.api.Test
+import kotlin.system.measureTimeMillis
 
 internal class ClientStoreTest {
 
@@ -18,6 +19,11 @@ internal class ClientStoreTest {
             with(ClientStore(DataSource.instance)) {
                 val client1 = oauth2Client("testclient")
                 storeClient(client1) shouldBe 1
+
+                // should only update the record if the data is different
+                storeClient(client1) shouldBe 0
+
+                // client1 has new data
                 val client2 = oauth2Client("testclient")
                 storeClient(client2) shouldBe 1
                 find("testclient") shouldBe client2
@@ -44,6 +50,69 @@ internal class ClientStoreTest {
                 val testclient = oauth2Client("testclient")
                 storeClient(testclient)
                 find("testclient") shouldBe testclient
+            }
+        }
+    }
+
+    @Test
+    fun findClients() {
+        withMigratedDb {
+            with(ClientStore(DataSource.instance)) {
+                val testclient = oauth2Client("testclient")
+                val testclient2 = oauth2Client("testclient2")
+                storeClient(testclient)
+                storeClient(testclient2)
+                findClients(listOf("testclient", "testclient2")) shouldBe mapOf(
+                    "testclient" to testclient,
+                    "testclient2" to testclient2
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testFindClientsAndStorePerformance() {
+        withMigratedDb {
+            with(ClientStore(DataSource.instance)) {
+                val clientIds = (1..50).map { "client:$it" }
+                val storeTimes = mutableListOf<Long>()
+
+                clientIds.forEach {
+                    val elapsedTime = measureTimeMillis {
+                        storeClient(oauth2Client(it))
+                    }
+                    // Skip the first client for average calculation, as it might be slower due to initialization
+                    if (it != "client:1") {
+                        storeTimes.add(elapsedTime)
+                        assert(elapsedTime < 400) { "storeClient took too long: $elapsedTime ms" }
+                    }
+                }
+
+                val averageStoreTime = storeTimes.average()
+                println("Average storeClient time: $averageStoreTime ms")
+                assert(averageStoreTime < 150) { "Average storeClient time: $averageStoreTime ms" }
+
+                // find each client
+                storeTimes.clear()
+                clientIds.forEach {
+                    val findClientElapsedTime = measureTimeMillis {
+                        find(it)
+                    }
+                    storeTimes.add(findClientElapsedTime)
+                    assert(findClientElapsedTime < 20) { "findClient took too long: $findClientElapsedTime ms" }
+                }
+
+                val averageFindTime = storeTimes.average()
+                println("Average findClient time: $averageFindTime ms")
+                println("Total findClient time: ${storeTimes.sum()} ms")
+                assert(storeTimes.sum() < 100) { "Average findClient time: $storeTimes.sum() ms" }
+
+                // bulk find
+                val findElapsedTime = measureTimeMillis {
+                    findClients(clientIds)
+                }
+                println("Total findClients time: $findElapsedTime ms")
+                assert(findElapsedTime < storeTimes.sum()) { "findClients took too long: $findElapsedTime ms, expected less than ${storeTimes.sum()} ms" }
             }
         }
     }


### PR DESCRIPTION
workflows:
* update runs-on

code:
* instead of looking up the clientId 2 times with find we bulk with both in same lookup, like a lazy lookup, if the audience is not present, the code fails like before.
* URL is deprecated, use URI().toURL()
* add findClients to clientRegistry
* add findClients to ClientStore, to map
* update upserQuery to only do update if there is changes to data

mock:
* update mocks

Tests
* tests new behaviour for storeClients
* add test for findClients
* simple benchmark, comparing find and findClients

consider:
validating audience input
cache of client data , either inmem or redis
cache of jwks is 6 hours, should it be longer?