### PR TITLE
fix(ktor): scalability for server

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ val kotestVersion = "5.9.1"
 val kotlinLoggingVersion = "3.0.5"
 val kotlinVersion = "2.0.21"
 val kotliqueryVersion = "1.9.0"
-val ktorVersion = "3.0.1"
+val ktorVersion = "3.0.2"
 val logbackVersion = "1.5.12"
 val logstashLogbackEncoderVersion = "8.0"
 val micrometerRegistryPrometheusVersion = "1.14.0"
@@ -52,6 +52,13 @@ java {
 
 repositories {
     mavenCentral()
+}
+
+
+configurations.all {
+    resolutionStrategy {
+        force("org.apache.commons:commons-compress:1.26.0")
+    }
 }
 
 dependencies {

--- a/charts/templates/tokendings.yaml
+++ b/charts/templates/tokendings.yaml
@@ -61,7 +61,7 @@ spec:
             envVarPrefix: DB
         flags:
           - name: max_connections
-            value: "200"
+            value: "300"
   ingresses:
     - "{{- include "tokenx.tokendings.URL" . }}"
   {{- if .Values.tokendings.mapSubjectTokenClaims }}

--- a/charts/templates/tokendings.yaml
+++ b/charts/templates/tokendings.yaml
@@ -59,6 +59,9 @@ spec:
         databases:
           - name: tokendings
             envVarPrefix: DB
+        flags:
+          - name: max_connections
+            value: "200"
   ingresses:
     - "{{- include "tokenx.tokendings.URL" . }}"
   {{- if .Values.tokendings.mapSubjectTokenClaims }}

--- a/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
@@ -87,9 +87,9 @@ fun server(): EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Conf
             connector {
                 port = config.serverProperties.port
             }
-            connectionGroupSize = 8
-            workerGroupSize = 8
-            callGroupSize = 16
+            connectionGroupSize = Runtime.getRuntime().availableProcessors()
+            workerGroupSize = Runtime.getRuntime().availableProcessors() * 2
+            callGroupSize = Runtime.getRuntime().availableProcessors() * 2
         },
         module = {
             tokenExchangeApp(config, DefaultRouting(config))
@@ -148,15 +148,9 @@ fun Application.tokenExchangeApp(config: AppConfiguration, routing: ApiRouting) 
                     val includeErrorDetails = isNonProd()
                     call.respondWithError(cause, includeErrorDetails)
                 }
-
-                is BadRequestException -> {
+                is BadRequestException, is JsonProcessingException -> {
                     call.respond(HttpStatusCode.BadRequest, "invalid request content")
                 }
-
-                is JsonProcessingException -> {
-                    call.respond(HttpStatusCode.BadRequest, "invalid request content")
-                }
-
                 else -> {
                     call.respond(HttpStatusCode.InternalServerError, "unknown internal server error")
                 }

--- a/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
@@ -81,15 +81,17 @@ fun main() {
 
 fun server(): EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Configuration> {
     val config = configByProfile()
+    val processors = Runtime.getRuntime().availableProcessors()
     return embeddedServer(
         Netty,
         configure = {
             connector {
                 port = config.serverProperties.port
             }
-            connectionGroupSize = Runtime.getRuntime().availableProcessors()
-            workerGroupSize = Runtime.getRuntime().availableProcessors() * 2
-            callGroupSize = Runtime.getRuntime().availableProcessors() * 2
+            // Balanced network handling with full CPU utilization for I/O and prioritize application logic
+            connectionGroupSize = processors / 2
+            workerGroupSize = processors
+            callGroupSize = processors * 2
         },
         module = {
             tokenExchangeApp(config, DefaultRouting(config))

--- a/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
@@ -90,7 +90,6 @@ fun server(): EmbeddedServer<NettyApplicationEngine, NettyApplicationEngine.Conf
             connector {
                 port = config.serverProperties.port
             }
-            // Balanced network handling with full CPU utilization for I/O and prioritize application logic
             connectionGroupSize = maxOf(1, processors / 2)
             workerGroupSize = processors
             callGroupSize = maxOf(1, minOf(processors * 2, maxConnectionPool))

--- a/src/main/kotlin/io/nais/security/oauth2/config/DatabaseConfig.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/config/DatabaseConfig.kt
@@ -60,8 +60,8 @@ object HikariProperties {
     const val IDLE_TIMEOUT_PROD = 300000L
     const val CONNECTION_TIMEOUT_PROD = 5000L
     const val MAX_LIFETIME_PROD = 1800000L
-    const val MAX_POOL_SIZE_PROD = 10
-    const val MIN_IDLE_CONNECTIONS_PROD = 5
+    const val MAX_POOL_SIZE_PROD = 20
+    const val MIN_IDLE_CONNECTIONS_PROD = 10
 
     // Non-production-specific
     const val IDLE_TIMEOUT_NON_PROD = 600000L


### PR DESCRIPTION
Noticed slow processing in ktor, when there is a high amount of load. The thread pool sizes (connectionGroupSize, workerGroupSize, and callGroupSize)  dynamically calculated based on the available processors, ensuring optimal performance.

This setup will be 16, 32, 32 instead of 8, 8, 16 -> This configuration assumes that application processing is more CPU-intensive than connection handling. Not true looking at metrics.

checking the docs:
If /token processing is delayed, we can increase callGroupSize gradually to handle more concurrent requests.

consider:
install(IdleTimeout) {
    requestTimeoutMillis = 15000
    idleTimeoutMillis = 60000
}

to handle connection not consuming resources use