### PR TITLE
feat: audience as MDC for CallLogging plugin and app logs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,6 +99,7 @@ dependencies {
     testImplementation("io.ktor:ktor-server-test-host-jvm:$ktorVersion")
     testImplementation("io.ktor:ktor-client-mock-jvm:$ktorVersion")
     runtimeOnly("ch.qos.logback:logback-classic:$logbackVersion")
+    testImplementation("ch.qos.logback:logback-classic:$logbackVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashLogbackEncoderVersion")
     testImplementation("com.h2database:h2:$h2Version")
     testImplementation("no.nav.security:mock-oauth2-server:$mockOAuth2ServerVersion")

--- a/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
@@ -43,6 +43,8 @@ import io.micrometer.core.instrument.binder.logging.LogbackMetrics
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics
 import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
+import io.nais.security.oauth2.authentication.ClientIdAttributeKey
+import io.nais.security.oauth2.authentication.AudienceAttributeKey
 import io.nais.security.oauth2.authentication.clientRegistrationAuth
 import io.nais.security.oauth2.config.AppConfiguration
 import io.nais.security.oauth2.config.HikariProperties
@@ -61,7 +63,8 @@ import kotlin.system.exitProcess
 import kotlin.time.Duration.Companion.seconds
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 
-private val log = KotlinLogging.logger { }
+internal val log = KotlinLogging.logger { }
+internal val appLoggerName: String = log.name
 
 fun main() {
     try {
@@ -114,6 +117,8 @@ fun Application.tokenExchangeApp(
         logger = log
         level = Level.INFO
         callIdMdc("callId")
+        mdc(ClientIdAttributeKey.name) { call -> call.attributes.getOrNull(ClientIdAttributeKey) }
+        mdc(AudienceAttributeKey.name) { call -> call.attributes.getOrNull(AudienceAttributeKey) }
         filter { call ->
             !call.request.path().startsWith("/internal/isalive") &&
                 !call.request.path().startsWith("/internal/isready") &&

--- a/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
@@ -43,8 +43,8 @@ import io.micrometer.core.instrument.binder.logging.LogbackMetrics
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics
 import io.micrometer.prometheus.PrometheusConfig
 import io.micrometer.prometheus.PrometheusMeterRegistry
-import io.nais.security.oauth2.authentication.ClientIdAttributeKey
 import io.nais.security.oauth2.authentication.AudienceAttributeKey
+import io.nais.security.oauth2.authentication.ClientIdAttributeKey
 import io.nais.security.oauth2.authentication.clientRegistrationAuth
 import io.nais.security.oauth2.config.AppConfiguration
 import io.nais.security.oauth2.config.HikariProperties

--- a/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestContext.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestContext.kt
@@ -7,6 +7,8 @@ import com.nimbusds.oauth2.sdk.OAuth2Error
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveParameters
+import io.ktor.util.AttributeKey
+import io.ktor.util.Attributes
 import io.nais.security.oauth2.model.ClientId
 import io.nais.security.oauth2.model.OAuth2Client
 import io.nais.security.oauth2.model.OAuth2Exception
@@ -23,6 +25,9 @@ typealias AcceptedAudience = Set<String>
 
 private val log = KotlinLogging.logger { }
 
+val ClientIdAttributeKey = AttributeKey<String>("client_id")
+val AudienceAttributeKey = AttributeKey<String>("audience")
+
 class TokenRequestContext private constructor(
     val oauth2Client: OAuth2Client,
     val oauth2TokenRequest: OAuth2TokenRequest,
@@ -33,22 +38,13 @@ class TokenRequestContext private constructor(
     )
 
     class From(
+        private val attributes: Attributes,
         private val parameters: Parameters,
     ) {
         @WithSpan
         fun authenticateAndAuthorize(configure: TokenRequestConfig.Configuration.(ClientIDs) -> Unit): TokenRequestContext {
             val credential = credential()
-            val config =
-                TokenRequestConfig(
-                    TokenRequestConfig.Configuration().apply {
-                        val clientIds =
-                            ClientIDs(
-                                client = credential.clientId,
-                                target = parameters.require("audience"),
-                            )
-                        configure(clientIds)
-                    },
-                )
+            val config = config(credential, configure)
             val client: OAuth2Client = authenticateClient(config, credential)
             val tokenRequest = authorizeTokenRequest(config, client)
             return TokenRequestContext(client, tokenRequest)
@@ -59,8 +55,26 @@ class TokenRequestContext private constructor(
                 parameters.require("client_assertion_type"),
                 parameters.require("client_assertion"),
             ).also { client ->
-                MDC.put("client_id", client.clientId)
+                MDC.put(ClientIdAttributeKey.name, client.clientId)
+                attributes.put(ClientIdAttributeKey, client.clientId)
             }
+
+        private fun config(
+            credential: ClientAssertionCredential,
+            configure: TokenRequestConfig.Configuration.(ClientIDs) -> Unit
+        ): TokenRequestConfig = TokenRequestConfig(
+            TokenRequestConfig.Configuration().apply {
+                val clientIds =
+                    ClientIDs(
+                        client = credential.clientId,
+                        target = parameters.require("audience"),
+                    )
+                configure(clientIds).also {
+                    MDC.put(AudienceAttributeKey.name, clientIds.target)
+                    attributes.put(AudienceAttributeKey, clientIds.target)
+                }
+            },
+        )
 
         @WithSpan
         private fun authenticateClient(
@@ -162,4 +176,4 @@ private fun SignedJWT.isWithinMaxLifetime(lifetime: Long): Boolean = this.expire
 
 @WithSpan(kind = SpanKind.CLIENT)
 suspend fun ApplicationCall.receiveTokenRequestContext(block: TokenRequestContext.From.() -> TokenRequestContext): TokenRequestContext =
-    block.invoke(TokenRequestContext.From(this.receiveParameters()))
+    block.invoke(TokenRequestContext.From(this.attributes, this.receiveParameters()))

--- a/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestContext.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestContext.kt
@@ -19,11 +19,12 @@ import io.nais.security.oauth2.token.verify
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.instrumentation.annotations.WithSpan
 import mu.KotlinLogging
-import org.slf4j.MDC
+import mu.withLoggingContext
 
 typealias AcceptedAudience = Set<String>
 
 private val log = KotlinLogging.logger { }
+internal val tokenRequestContextLoggerName: String = log.name
 
 val ClientIdAttributeKey = AttributeKey<String>("client_id")
 val AudienceAttributeKey = AttributeKey<String>("audience")
@@ -55,26 +56,25 @@ class TokenRequestContext private constructor(
                 parameters.require("client_assertion_type"),
                 parameters.require("client_assertion"),
             ).also { client ->
-                MDC.put(ClientIdAttributeKey.name, client.clientId)
                 attributes.put(ClientIdAttributeKey, client.clientId)
             }
 
         private fun config(
             credential: ClientAssertionCredential,
-            configure: TokenRequestConfig.Configuration.(ClientIDs) -> Unit
-        ): TokenRequestConfig = TokenRequestConfig(
-            TokenRequestConfig.Configuration().apply {
-                val clientIds =
-                    ClientIDs(
-                        client = credential.clientId,
-                        target = parameters.require("audience"),
-                    )
-                configure(clientIds).also {
-                    MDC.put(AudienceAttributeKey.name, clientIds.target)
-                    attributes.put(AudienceAttributeKey, clientIds.target)
-                }
-            },
-        )
+            configure: TokenRequestConfig.Configuration.(ClientIDs) -> Unit,
+        ): TokenRequestConfig {
+            val clientIds =
+                ClientIDs(
+                    client = credential.clientId,
+                    target = parameters.require("audience"),
+                )
+            attributes.put(AudienceAttributeKey, clientIds.target)
+            return TokenRequestConfig(
+                TokenRequestConfig.Configuration().apply {
+                    configure(clientIds)
+                },
+            )
+        }
 
         @WithSpan
         private fun authenticateClient(
@@ -88,7 +88,12 @@ class TokenRequestContext private constructor(
                         oAuth2Client.jwkSet.keys
                             .map { it.keyID }
                             .toList()
-                    log.info("verify client_assertion for client_id=${oAuth2Client.clientId} with keyIds=$keyIds")
+                    withLoggingContext(
+                        ClientIdAttributeKey.name to oAuth2Client.clientId,
+                        AudienceAttributeKey.name to (attributes.getOrNull(AudienceAttributeKey) ?: ""),
+                    ) {
+                        log.info("verify client_assertion for client_id=${oAuth2Client.clientId} with keyIds=$keyIds")
+                    }
                     clientAssertionCredential.signedJWT.verify(
                         config.claimsVerifier(oAuth2Client.clientId),
                         oAuth2Client.jwkSet,

--- a/src/test/kotlin/io/nais/security/oauth2/mock/MockConfiguration.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/mock/MockConfiguration.kt
@@ -1,5 +1,7 @@
 package io.nais.security.oauth2.mock
 
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import com.zaxxer.hikari.HikariDataSource
 import io.ktor.server.application.Application
 import io.nais.security.oauth2.config.AppConfiguration
@@ -22,6 +24,7 @@ import io.nais.security.oauth2.routing.DefaultRouting
 import io.nais.security.oauth2.tokenExchangeApp
 import io.nais.security.oauth2.utils.jwkSet
 import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.slf4j.LoggerFactory
 import org.testcontainers.containers.PostgreSQLContainer
 import java.time.Duration
 
@@ -115,6 +118,17 @@ fun <R> withMockOAuth2Server(test: MockOAuth2Server.() -> R): R {
         return server.test()
     } finally {
         server.shutdown()
+    }
+}
+
+fun <R> withLogAppender(loggerName: String, test: ListAppender<ILoggingEvent>.() -> R): R {
+    val logger = LoggerFactory.getLogger(loggerName) as ch.qos.logback.classic.Logger
+    val appender = ListAppender<ILoggingEvent>().apply { start() }
+    logger.addAppender(appender)
+    try {
+        return appender.test()
+    } finally {
+        logger.detachAppender(appender)
     }
 }
 

--- a/src/test/kotlin/io/nais/security/oauth2/mock/MockConfiguration.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/mock/MockConfiguration.kt
@@ -121,14 +121,18 @@ fun <R> withMockOAuth2Server(test: MockOAuth2Server.() -> R): R {
     }
 }
 
-fun <R> withLogAppender(loggerName: String, test: ListAppender<ILoggingEvent>.() -> R): R {
+fun <R> withLogAppender(
+    loggerName: String,
+    test: ListAppender<ILoggingEvent>.() -> R,
+): R {
     val logger = LoggerFactory.getLogger(loggerName) as ch.qos.logback.classic.Logger
     val appender = ListAppender<ILoggingEvent>().apply { start() }
     logger.addAppender(appender)
-    try {
-        return appender.test()
+    return try {
+        appender.test()
     } finally {
         logger.detachAppender(appender)
+        appender.stop()
     }
 }
 

--- a/src/test/kotlin/io/nais/security/oauth2/routing/TokenExchangeApiTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/routing/TokenExchangeApiTest.kt
@@ -18,11 +18,13 @@ import io.ktor.http.HttpHeaders.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.formUrlEncode
 import io.ktor.server.testing.testApplication
+import io.nais.security.oauth2.appLoggerName
 import io.nais.security.oauth2.config.AppConfiguration
 import io.nais.security.oauth2.config.AuthorizationServerProperties.Companion.JWKS_PATH
 import io.nais.security.oauth2.config.AuthorizationServerProperties.Companion.WELL_KNOWN_PATH
 import io.nais.security.oauth2.mock.MockClientRegistry
 import io.nais.security.oauth2.mock.mockConfig
+import io.nais.security.oauth2.mock.withLogAppender
 import io.nais.security.oauth2.mock.withMockOAuth2Server
 import io.nais.security.oauth2.model.AccessPolicy
 import io.nais.security.oauth2.model.ClientId
@@ -101,16 +103,7 @@ internal class TokenExchangeApiTest {
                 val response =
                     client.post("/token") {
                         header(ContentType, FormUrlEncoded.toString())
-                        setBody(
-                            listOf(
-                                "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                                "client_assertion" to clientAssertion,
-                                "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                                "audience" to client2.clientId,
-                                "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                                "subject_token" to subjectToken.serialize(),
-                            ).formUrlEncode(),
-                        )
+                        setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectToken.serialize()))
                     }
                 assertThat(response.status).isEqualTo(HttpStatusCode.OK)
                 val accessTokenResponse: OAuth2TokenResponse = mapper.readValue(response.bodyAsText())
@@ -139,16 +132,7 @@ internal class TokenExchangeApiTest {
                 val response =
                     client.post("/token") {
                         header(ContentType, FormUrlEncoded.toString())
-                        setBody(
-                            listOf(
-                                "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                                "client_assertion" to clientAssertion,
-                                "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                                "audience" to client2.clientId,
-                                "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                                "subject_token" to subjectToken.serialize(),
-                            ).formUrlEncode(),
-                        )
+                        setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectToken.serialize()))
                     }
                 assertThat(response.status).isEqualTo(HttpStatusCode.OK)
                 val accessTokenResponse: OAuth2TokenResponse = mapper.readValue(response.bodyAsText())
@@ -175,16 +159,7 @@ internal class TokenExchangeApiTest {
                 application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
                 client.post("/token") {
                     header(ContentType, FormUrlEncoded.toString())
-                    setBody(
-                        listOf(
-                            "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                            "client_assertion" to clientAssertion,
-                            "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                            "audience" to client2.clientId,
-                            "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                            "subject_token" to subjectToken.serialize(),
-                        ).formUrlEncode(),
-                    )
+                    setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectToken.serialize()))
                 } shouldBeObject
                     OAuth2Error.INVALID_REQUEST
                         .setDescription("client '${client1.clientId}' is not authorized to get token with aud=${client2.clientId}")
@@ -202,16 +177,7 @@ internal class TokenExchangeApiTest {
                 application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
                 client.post("/token") {
                     header(ContentType, FormUrlEncoded.toString())
-                    setBody(
-                        listOf(
-                            "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                            "client_assertion" to unknownClientAssertion,
-                            "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                            "audience" to "client2",
-                            "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                            "subject_token" to "sometoken",
-                        ).formUrlEncode(),
-                    )
+                    setBody(tokenExchangeBody(unknownClientAssertion, "client2", "sometoken"))
                 } shouldBeObject OAuth2Error.INVALID_CLIENT.setDescription("invalid client authentication for client_id=unknown, client not registered.")
             }
         }
@@ -228,16 +194,7 @@ internal class TokenExchangeApiTest {
                 application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
                 client.post("/token") {
                     header(ContentType, FormUrlEncoded.toString())
-                    setBody(
-                        listOf(
-                            "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                            "client_assertion" to invalidClientAssertion,
-                            "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                            "audience" to "client2",
-                            "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                            "subject_token" to "sometoken",
-                        ).formUrlEncode(),
-                    )
+                    setBody(tokenExchangeBody(invalidClientAssertion, "client2", "sometoken"))
                 } shouldBeObject
                     OAuth2Error.INVALID_REQUEST
                         .setDescription("token verification failed: Signed+JWT+rejected%3A+Another+algorithm+expected%2C+or+no+matching+key%28s%29+found")
@@ -261,16 +218,7 @@ internal class TokenExchangeApiTest {
                 application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
                 client.post("/token") {
                     header(ContentType, FormUrlEncoded.toString())
-                    setBody(
-                        listOf(
-                            "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                            "client_assertion" to invalidClientAssertion,
-                            "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                            "audience" to "client2",
-                            "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                            "subject_token" to "sometoken",
-                        ).formUrlEncode(),
-                    )
+                    setBody(tokenExchangeBody(invalidClientAssertion, "client2", "sometoken"))
                 } shouldBeObject
                     OAuth2Error.INVALID_REQUEST
                         .setDescription(
@@ -295,16 +243,7 @@ internal class TokenExchangeApiTest {
                 application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
                 client.post("/token") {
                     header(ContentType, FormUrlEncoded.toString())
-                    setBody(
-                        listOf(
-                            "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                            "client_assertion" to invalidClientAssertion,
-                            "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                            "audience" to "client2",
-                            "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                            "subject_token" to "sometoken",
-                        ).formUrlEncode(),
-                    )
+                    setBody(tokenExchangeBody(invalidClientAssertion, "client2", "sometoken"))
                 } shouldBeObject
                     OAuth2Error.INVALID_REQUEST
                         .setDescription(
@@ -328,16 +267,7 @@ internal class TokenExchangeApiTest {
                 application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
                 client.post("/token") {
                     header(ContentType, FormUrlEncoded.toString())
-                    setBody(
-                        listOf(
-                            "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                            "client_assertion" to clientAssertion,
-                            "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                            "audience" to client2.clientId,
-                            "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                            "subject_token" to subjectToken.serialize(),
-                        ).formUrlEncode(),
-                    )
+                    setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectToken.serialize()))
                 } shouldBeObject
                     OAuth2Error.INVALID_CLIENT
                         .setDescription(
@@ -366,16 +296,7 @@ internal class TokenExchangeApiTest {
                 application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
                 client.post("/token") {
                     header(ContentType, FormUrlEncoded.toString())
-                    setBody(
-                        listOf(
-                            "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                            "client_assertion" to clientAssertion,
-                            "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                            "audience" to client2.clientId,
-                            "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                            "subject_token" to subjectToken.serialize(),
-                        ).formUrlEncode(),
-                    )
+                    setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectToken.serialize()))
                 } shouldBeObject OAuth2Error.INVALID_REQUEST.setDescription("token verification failed: JWT+before+use+time")
             }
         }
@@ -406,16 +327,7 @@ internal class TokenExchangeApiTest {
                 application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
                 client.post("/token") {
                     header(ContentType, FormUrlEncoded.toString())
-                    setBody(
-                        listOf(
-                            "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                            "client_assertion" to clientAssertion,
-                            "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                            "audience" to client2.clientId,
-                            "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                            "subject_token" to subjectToken.serialize(),
-                        ).formUrlEncode(),
-                    )
+                    setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectToken.serialize()))
                 } shouldBeObject OAuth2Error.INVALID_REQUEST.setDescription("invalid request, cannot parse token")
             }
         }
@@ -435,16 +347,7 @@ internal class TokenExchangeApiTest {
                 application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
                 client.post("/token") {
                     header(ContentType, FormUrlEncoded.toString())
-                    setBody(
-                        listOf(
-                            "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                            "client_assertion" to clientAssertion,
-                            "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                            "audience" to client2.clientId,
-                            "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                            "subject_token" to subjectTokenSerialized,
-                        ).formUrlEncode(),
-                    )
+                    setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectTokenSerialized))
                 } shouldBeObject
                     OAuth2Error.INVALID_REQUEST
                         .setDescription("invalid subject_token: invalid request, cannot validate token from issuer=${subjectToken.jwtClaimsSet.issuer}")
@@ -476,16 +379,7 @@ internal class TokenExchangeApiTest {
                 application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
                 client.post("/token") {
                     header(ContentType, FormUrlEncoded.toString())
-                    setBody(
-                        listOf(
-                            "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                            "client_assertion" to clientAssertion,
-                            "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                            "audience" to client2.clientId,
-                            "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                            "subject_token" to subjectToken,
-                        ).formUrlEncode(),
-                    )
+                    setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectToken))
                 } shouldBeObject OAuth2Error.INVALID_REQUEST.setDescription("invalid subject_token: invalid request, cannot parse token")
             }
         }
@@ -506,22 +400,79 @@ internal class TokenExchangeApiTest {
                 application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
                 client.post("/token") {
                     header(ContentType, FormUrlEncoded.toString())
-                    setBody(
-                        listOf(
-                            "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                            "client_assertion" to clientAssertion,
-                            "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
-                            "audience" to client2.clientId,
-                            "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
-                            "subject_token" to subjectToken.serialize(),
-                        ).formUrlEncode(),
-                    )
+                    setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectToken.serialize()))
                 } shouldBeObject OAuth2Error.INVALID_REQUEST.setDescription("invalid subject_token: token verification failed: Expired+JWT")
             }
         }
     }
 
+    @Test
+    fun `successful token exchange is logged with MDC callId, client_id and audience`() {
+        withMockOAuth2Server {
+            val mockConfig = mockConfig(this)
+            val client1 = mockConfig.mockClientRegistry().register("client1")
+            val client2 = mockConfig.mockClientRegistry().register("client2", AccessPolicy(listOf("client1")))
+            val clientAssertion = client1.createClientAssertion(mockConfig.authorizationServerProperties.tokenEndpointUrl())
+            val subjectToken = this.issueToken("mock1", "someclientid", DefaultOAuth2TokenCallback())
+
+            withLogAppender(appLoggerName) {
+                testApplication {
+                    application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
+                    client.post("/token") {
+                        header(ContentType, FormUrlEncoded.toString())
+                        setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectToken.serialize()))
+                    }
+                }
+                assertThat(list).isNotEmpty
+                val eventWithMdc = list.first { it.mdcPropertyMap["callId"]?.isNotBlank() == true }
+                assertThat(eventWithMdc.mdcPropertyMap["callId"]).isNotBlank
+                assertThat(eventWithMdc.mdcPropertyMap["client_id"]).isEqualTo("client1")
+                assertThat(eventWithMdc.mdcPropertyMap["audience"]).isEqualTo("client2")
+            }
+        }
+    }
+
+    @Test
+    fun `unsuccessful token exchange is logged with MDC callId, client_id and audience`() {
+        withMockOAuth2Server {
+            val mockConfig = mockConfig(this)
+            val client1 = mockConfig.mockClientRegistry().register("client1")
+            // client1 is not authorized to request token for client2
+            val client2 = mockConfig.mockClientRegistry().register("client2", AccessPolicy(listOf("client3")))
+            val clientAssertion = client1.createClientAssertion(mockConfig.authorizationServerProperties.tokenEndpointUrl())
+            val subjectToken = this.issueToken("mock1", "someclientid", DefaultOAuth2TokenCallback())
+
+            withLogAppender(appLoggerName) {
+                testApplication {
+                    application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
+                    client.post("/token") {
+                        header(ContentType, FormUrlEncoded.toString())
+                        setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectToken.serialize()))
+                    }
+                }
+                assertThat(list).isNotEmpty
+                val eventWithMdc = list.first { it.mdcPropertyMap["callId"]?.isNotBlank() == true }
+                assertThat(eventWithMdc.mdcPropertyMap["callId"]).isNotBlank
+                assertThat(eventWithMdc.mdcPropertyMap["client_id"]).isEqualTo("client1")
+                assertThat(eventWithMdc.mdcPropertyMap["audience"]).isEqualTo("client2")
+            }
+        }
+    }
+
     private fun AppConfiguration.mockClientRegistry() = this.clientRegistry as MockClientRegistry
+
+    private fun tokenExchangeBody(
+        clientAssertion: String,
+        audience: String,
+        subjectToken: String,
+    ) = listOf(
+        "client_assertion_type" to "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        "client_assertion" to clientAssertion,
+        "grant_type" to "urn:ietf:params:oauth:grant-type:token-exchange",
+        "audience" to audience,
+        "subject_token_type" to "urn:ietf:params:oauth:token-type:jwt",
+        "subject_token" to subjectToken,
+    ).formUrlEncode()
 
     private fun oAuth2Client(clientId: ClientId = "unknown") = OAuth2Client(clientId, JsonWebKeys(jwkSet()))
 

--- a/src/test/kotlin/io/nais/security/oauth2/routing/TokenExchangeApiTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/routing/TokenExchangeApiTest.kt
@@ -19,6 +19,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.formUrlEncode
 import io.ktor.server.testing.testApplication
 import io.nais.security.oauth2.appLoggerName
+import io.nais.security.oauth2.authentication.tokenRequestContextLoggerName
 import io.nais.security.oauth2.config.AppConfiguration
 import io.nais.security.oauth2.config.AuthorizationServerProperties.Companion.JWKS_PATH
 import io.nais.security.oauth2.config.AuthorizationServerProperties.Companion.WELL_KNOWN_PATH
@@ -455,6 +456,80 @@ internal class TokenExchangeApiTest {
                 assertThat(eventWithMdc.mdcPropertyMap["callId"]).isNotBlank
                 assertThat(eventWithMdc.mdcPropertyMap["client_id"]).isEqualTo("client1")
                 assertThat(eventWithMdc.mdcPropertyMap["audience"]).isEqualTo("client2")
+            }
+        }
+    }
+
+    @Test
+    fun `in-flight log inside route handler carries client_id and audience via withLoggingContext`() {
+        withMockOAuth2Server {
+            val mockConfig = mockConfig(this)
+            val client1 = mockConfig.mockClientRegistry().register("client1")
+            val client2 = mockConfig.mockClientRegistry().register("client2", AccessPolicy(listOf("client1")))
+            val clientAssertion = client1.createClientAssertion(mockConfig.authorizationServerProperties.tokenEndpointUrl())
+            val subjectToken = this.issueToken("mock1", "someclientid", DefaultOAuth2TokenCallback())
+
+            withLogAppender(tokenRequestContextLoggerName) {
+                testApplication {
+                    application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
+                    client.post("/token") {
+                        header(ContentType, FormUrlEncoded.toString())
+                        setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectToken.serialize()))
+                    }
+                }
+                assertThat(list).isNotEmpty
+                val verifyEvent = list.first { it.formattedMessage.startsWith("verify client_assertion") }
+                assertThat(verifyEvent.mdcPropertyMap["client_id"]).isEqualTo("client1")
+                assertThat(verifyEvent.mdcPropertyMap["audience"]).isEqualTo("client2")
+            }
+        }
+    }
+
+    @Test
+    fun `subsequent request does not inherit MDC client_id or audience from previous request`() {
+        withMockOAuth2Server {
+            val mockConfig = mockConfig(this)
+            val client1 = mockConfig.mockClientRegistry().register("client1")
+            val client2 = mockConfig.mockClientRegistry().register("client2", AccessPolicy(listOf("client1")))
+            val clientAssertion = client1.createClientAssertion(mockConfig.authorizationServerProperties.tokenEndpointUrl())
+            val subjectToken = this.issueToken("mock1", "someclientid", DefaultOAuth2TokenCallback())
+
+            withLogAppender(appLoggerName) {
+                testApplication {
+                    application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
+                    // Request 1: populates MDC for client1/client2
+                    client.post("/token") {
+                        header(ContentType, FormUrlEncoded.toString())
+                        setBody(tokenExchangeBody(clientAssertion, client2.clientId, subjectToken.serialize()))
+                    }
+                    // Request 2: a route that never touches TokenRequestContext
+                    client.get(JWKS_PATH)
+                }
+                val jwksEvent = list.first { it.formattedMessage.contains(JWKS_PATH) && it.mdcPropertyMap["callId"]?.isNotBlank() == true }
+                assertThat(jwksEvent.mdcPropertyMap).doesNotContainKey("client_id")
+                assertThat(jwksEvent.mdcPropertyMap).doesNotContainKey("audience")
+            }
+        }
+    }
+
+    @Test
+    fun `failed client authentication logs client_id=unknown and audience in MDC`() {
+        withMockOAuth2Server {
+            val mockConfig = mockConfig(this)
+            val unknownClientAssertion = oAuth2Client().createClientAssertion(mockConfig.authorizationServerProperties.tokenEndpointUrl())
+
+            withLogAppender(appLoggerName) {
+                testApplication {
+                    application { tokenExchangeApp(mockConfig, DefaultRouting(mockConfig)) }
+                    client.post("/token") {
+                        header(ContentType, FormUrlEncoded.toString())
+                        setBody(tokenExchangeBody(unknownClientAssertion, "some-audience", "sometoken"))
+                    }
+                }
+                assertThat(list).isNotEmpty
+                val eventWithMdc = list.first { it.mdcPropertyMap["callId"]?.isNotBlank() == true }
+                assertThat(eventWithMdc.mdcPropertyMap["client_id"]).isEqualTo("unknown")
+                assertThat(eventWithMdc.mdcPropertyMap["audience"]).isEqualTo("some-audience")
             }
         }
     }


### PR DESCRIPTION
This is an attempt to solve https://github.com/nais/tokendings/issues/601. From the issue:
> With regards to logging: we would prefer to have logs for which clients perform exchanges (successful or not) with which audiences. Would you consider accepting a PR which adds some additional logging and/or MDC fields for logs of type INFO, for instance adding the target audience of an exchange request as an MDC field together with the client_id?

Previously, app logs like the "verify client_assertions for..." info log in TokenRequestContext only contained the callId and client_id fields as MDC. Here, the audience is added as well. This means the resulting log lines can be used to investigate which clients are exchanging or attempting to exchange tokens for which audiences.

Additionally, the logs produced by the CallLogging plugin would not contain the MDC values set by the MDC.put(...) call. This is because of the coroutine-based nature of Ktor, where the calls to MDC.put(...) only affects the thread-local MDC. Adding the client_id and audience values to the attributes of the ApplicationCall makes them available in the CallLogging plugin.

I choose to test 2xx and 4xxcases, to ensure that Ktor failure handling works as expected with the MDC introduced in CallLogging. I expose the logger name of TokenExchangeApp as a val, to avoid writing the package directly in the tests.

Ktor CallLogging will clear MDC between subsequent calls. Do note that with regards to the thread-local MDC, stale MDC may be logged if a suspension point occurs between MDC.put and a log statement. There is no such call in the code currently.