### PR TITLE
feat(charts): add PrometheusRules for tokendings

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: tokenx
 description: Tokendings chart
 type: application
-version: 0.4.5
+version: 0.4.6
 sources:
   - https://github.com/nais/tokendings/tree/master/charts

--- a/charts/templates/prometheusrule.yaml
+++ b/charts/templates/prometheusrule.yaml
@@ -22,7 +22,6 @@ spec:
             action: |
               Investigate reason for restarts.
               Check the error logs and traces in the Grafana dashboard.
-            runbook_url: "https://github.com/nais/vakt/blob/master/tokendings.md"
 
         - alert: Tokendings high rate of OAuth2 errors
           expr: |
@@ -37,7 +36,6 @@ spec:
             action: |
               Check the dashboard and logs for the error code.
               Common causes: misconfigured clients, invalid subject tokens, expired keys.
-            runbook_url: "https://github.com/nais/vakt/blob/master/tokendings.md"
 
         - alert: Tokendings high rate of HTTP 5xx responses
           expr: |
@@ -55,5 +53,4 @@ spec:
             action: |
               Investigate reason for errors.
               Check the error logs, traces and dependencies (database, identity providers) in the Grafana dashboard.
-            runbook_url: "https://github.com/nais/vakt/blob/master/tokendings.md"
 {{- end }}

--- a/charts/templates/prometheusrule.yaml
+++ b/charts/templates/prometheusrule.yaml
@@ -22,6 +22,7 @@ spec:
             action: |
               Investigate reason for restarts.
               Check the error logs and traces in the Grafana dashboard.
+            dashboard_url: "https://monitoring.nais.io/d/Ebu1ICOGk/tokenx-tokendings?var-tenant={{ .Values.fasit.tenant.name }}&var-cluster={{ .Values.fasit.env.name }}"
 
         - alert: Tokendings high rate of OAuth2 errors
           expr: |
@@ -36,6 +37,7 @@ spec:
             action: |
               Check the dashboard and logs for the error code.
               Common causes: misconfigured clients, invalid subject tokens, expired keys.
+            dashboard_url: "https://monitoring.nais.io/d/Ebu1ICOGk/tokenx-tokendings?var-tenant={{ .Values.fasit.tenant.name }}&var-cluster={{ .Values.fasit.env.name }}"
 
         - alert: Tokendings high rate of HTTP 5xx responses
           expr: |
@@ -53,4 +55,5 @@ spec:
             action: |
               Investigate reason for errors.
               Check the error logs, traces and dependencies (database, identity providers) in the Grafana dashboard.
+            dashboard_url: "https://monitoring.nais.io/d/Ebu1ICOGk/tokenx-tokendings?var-tenant={{ .Values.fasit.tenant.name }}&var-cluster={{ .Values.fasit.env.name }}"
 {{- end }}

--- a/charts/templates/prometheusrule.yaml
+++ b/charts/templates/prometheusrule.yaml
@@ -1,0 +1,59 @@
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "tokenx.fullname" . }}-tokendings
+  labels:
+    {{- include "tokenx.tokendings.labels" . | nindent 4 }}
+spec:
+  groups:
+    - name: "tokendings-alerts"
+      rules:
+        - alert: Tokendings restarting continuously
+          expr: |
+            sum by (namespace,pod,uid) (changes(kube_pod_container_status_restarts_total{container=~".*-tokendings"}[1h])) * on(uid) group_left kube_pod_status_phase{phase="Running"} > 5
+          for: 10m
+          labels:
+            severity: warning
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: '{{ "Multiple restarts of Tokendings in pod `{{ $labels.namespace }}/{{ $labels.pod }}` the last hour" }}'
+            consequence: Applications that depend on Tokendings (TokenX) may be unable to exchange tokens, breaking authentication between services.
+            action: |
+              Investigate reason for restarts.
+              Check the error logs and traces in the Grafana dashboard.
+            runbook_url: "https://github.com/nais/vakt/blob/master/tokendings.md"
+
+        - alert: Tokendings high rate of OAuth2 errors
+          expr: |
+            sum by (namespace, code) (rate(tokendings_oauth2_errors[5m])) > 1
+          for: 15m
+          labels:
+            severity: warning
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: '{{ "Tokendings is returning OAuth2 errors with code `{{ $labels.code }}` at an elevated rate" }}'
+            consequence: Applications may be unable to exchange tokens, leading to authentication failures between services.
+            action: |
+              Check the dashboard and logs for the error code.
+              Common causes: misconfigured clients, invalid subject tokens, expired keys.
+            runbook_url: "https://github.com/nais/vakt/blob/master/tokendings.md"
+
+        - alert: Tokendings high rate of HTTP 5xx responses
+          expr: |
+            sum by (namespace) (rate(ktor_http_server_requests_seconds_count{app=~".*-tokendings", status=~"5.."}[5m]))
+            /
+            sum by (namespace) (rate(ktor_http_server_requests_seconds_count{app=~".*-tokendings"}[5m]))
+            > 0.10
+          for: 10m
+          labels:
+            severity: critical
+            namespace: {{ .Release.Namespace }}
+          annotations:
+            summary: '{{ "Tokendings is responding with HTTP 5xx for over 10% of requests the last 10 minutes" }}'
+            consequence: Token exchange is failing for a significant share of clients; authentication between services is degraded.
+            action: |
+              Investigate reason for errors.
+              Check the error logs, traces and dependencies (database, identity providers) in the Grafana dashboard.
+            runbook_url: "https://github.com/nais/vakt/blob/master/tokendings.md"
+{{- end }}

--- a/charts/templates/prometheusrule.yaml
+++ b/charts/templates/prometheusrule.yaml
@@ -11,13 +11,13 @@ spec:
       rules:
         - alert: Tokendings restarting continuously
           expr: |
-            sum by (namespace,pod,uid) (changes(kube_pod_container_status_restarts_total{container=~".*-tokendings"}[1h])) * on(uid) group_left kube_pod_status_phase{phase="Running"} > 5
+            sum by (pod,uid) (changes(kube_pod_container_status_restarts_total{container="{{ include "tokenx.fullname" . }}-tokendings"}[1h])) * on(uid) group_left kube_pod_status_phase{phase="Running"} > 5
           for: 10m
           labels:
             severity: warning
             namespace: {{ .Release.Namespace }}
           annotations:
-            summary: '{{ "Multiple restarts of Tokendings in pod `{{ $labels.namespace }}/{{ $labels.pod }}` the last hour" }}'
+            summary: '{{ "Multiple restarts of Tokendings in pod `{{ $labels.pod }}` the last hour" }}'
             consequence: Applications that depend on Tokendings (TokenX) may be unable to exchange tokens, breaking authentication between services.
             action: |
               Investigate reason for restarts.
@@ -26,7 +26,7 @@ spec:
 
         - alert: Tokendings high rate of OAuth2 errors
           expr: |
-            sum by (namespace, code) (rate(tokendings_oauth2_errors[5m])) > 1
+            sum by (code) (rate(tokendings_oauth2_errors[5m])) > 1
           for: 15m
           labels:
             severity: warning
@@ -41,9 +41,9 @@ spec:
 
         - alert: Tokendings high rate of HTTP 5xx responses
           expr: |
-            sum by (namespace) (rate(ktor_http_server_requests_seconds_count{app=~".*-tokendings", status=~"5.."}[5m]))
+            sum(rate(ktor_http_server_requests_seconds_count{app="{{ include "tokenx.fullname" . }}-tokendings", status=~"5.."}[5m]))
             /
-            sum by (namespace) (rate(ktor_http_server_requests_seconds_count{app=~".*-tokendings"}[5m]))
+            sum(rate(ktor_http_server_requests_seconds_count{app="{{ include "tokenx.fullname" . }}-tokendings"}[5m]))
             > 0.10
           for: 10m
           labels:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -2,6 +2,12 @@ repository: europe-north1-docker.pkg.dev/nais-io/nais/images
 
 team: nais
 
+fasit: # mapped from Fasit
+  tenant:
+    name: ""
+  env:
+    name: ""
+
 networkPolicy:
   enabled: false
   apiServerCIDR:

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,6 @@
 [tools]
 java = "temurin-21.0.10+7.0.LTS"
+helm = "3.16.2"
 step = "0.30.2"
 
 [tasks.services]
@@ -14,3 +15,7 @@ run = "./gradlew run"
 [tasks.test-exchange]
 description = "End-to-end token exchange against the local Tokendings"
 run = "./scripts/test-token-exchange.sh"
+
+[tasks."check:helm-lint"]
+description = "Lint helm chart"
+run = "helm lint --strict ./charts"


### PR DESCRIPTION
Implements [nais/system#509](https://github.com/nais/system/pull/509) — TokenX: Sette opp manglende PrometheusRules.

## What

Adds `charts/templates/prometheusrule.yaml` with three alerts:

| Alert | Severity | Trigger |
|---|---|---|
| Tokendings restarting continuously | warning | >5 restarts in 1h, sustained 10m |
| Tokendings high rate of OAuth2 errors | warning | `rate(tokendings_oauth2_errors[5m]) > 1` for 15m, grouped by code |
| Tokendings high rate of HTTP 5xx responses | critical | >10% 5xx for 10m |

Pattern matches [nais/texas](https://github.com/nais/texas/blob/main/charts/texas/templates/prometheusrule.yaml) and [nais/digdirator](https://github.com/nais/digdirator/blob/master/charts/templates/prometheusrule.yml).

## Notes

- Guarded by `.Capabilities.APIVersions.Has "monitoring.coreos.com/v1"` so the chart still applies on clusters without prometheus-operator.
- Chart bumped 0.4.5 → 0.4.6.
- No `dashboard_url`/`runbook_url` annotations yet — we'll add those once we have a Grafana dashboard at monitoring.nais.io.
- Thresholds are starting points; happy to tune based on real traffic data.

## Verification

- `helm template` with `--api-versions monitoring.coreos.com/v1` renders cleanly.
- `helm template` without that flag skips the file (guard works).
- `helm lint` passes.