### PR TITLE
build: bump dependencies, Gradle 9, replace shadow with installDist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           cache-provider: basic
       - name: Build with Gradle
-        run: ./gradlew clean build
+        run: ./gradlew clean build installDist

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,14 +36,14 @@ jobs:
           cache-provider: basic
           dependency-graph: generate-and-submit
       - name: Gradle build
-        run: ./gradlew build
+        run: ./gradlew build installDist
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # ratchet:sigstore/cosign-installer@v4.1.1
       - name: Verify distroless base image
         run: |
           cosign verify \
           --certificate-identity "keyless@distroless.iam.gserviceaccount.com" \
           --certificate-oidc-issuer "https://accounts.google.com" \
-          gcr.io/distroless/java21-debian12:nonroot
+          gcr.io/distroless/java21-debian13:nonroot
       - name: "Build and push image"
         uses: nais/platform-build-push-sign@df590279b21bc5978519685752f9eaddd546043c # ratchet:nais/platform-build-push-sign@main
         id: build-push-sign

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21-debian12:nonroot
+FROM gcr.io/distroless/java21-debian13:nonroot
 
 COPY build/libs/app-*.jar /app/app.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM gcr.io/distroless/java21-debian13:nonroot
 
-COPY build/libs/app-*.jar /app/app.jar
+COPY build/install/*/lib /app/lib
 
-WORKDIR /app
-
-CMD ["app.jar"]
-
+ENTRYPOINT ["java", "-cp", "/app/lib/*", "io.nais.security.oauth2.TokenExchangeAppKt"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,6 +119,7 @@ tasks {
     withType<KotlinJvmCompile>().configureEach {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_21)
+            freeCompilerArgs.add("-Xannotation-default-target=param-property")
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,28 +2,28 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
-val assertjVersion = "3.27.3"
-val dropWizardVersion = "4.2.33"
-val flywayVersion = "11.10.0"
-val h2Version = "2.3.232"
-val hikaricpVersion = "6.3.0"
-val junitJupiterVersion = "5.13.2"
+val assertjVersion = "3.27.7"
+val dropWizardVersion = "4.2.38"
+val flywayVersion = "12.5.0"
+val h2Version = "2.4.240"
+val hikaricpVersion = "7.0.2"
+val junitJupiterVersion = "6.0.3"
 val konfigVersion = "1.6.10.0"
-val kotestVersion = "5.9.1"
+val kotestVersion = "6.1.11"
 val kotlinLoggingVersion = "3.0.5"
-val kotlinVersion = "2.2.0"
+val kotlinVersion = "2.3.21"
 val kotliqueryVersion = "1.9.1"
-val ktorVersion = "3.3.3"
-val logbackVersion = "1.5.18"
-val logstashLogbackEncoderVersion = "8.1"
-val micrometerRegistryPrometheusVersion = "1.15.1"
-val mockOAuth2ServerVersion = "2.2.1"
-val mockWebServerVersion = "4.12.0"
-val mockkVersion = "1.14.4"
-val nimbusSdkVersion = "11.26"
-val openTelemetryAnnotationsVersion = "2.17.0"
-val openTelemetryVersion = "1.51.0"
-val postgresqlVersion = "42.7.7"
+val ktorVersion = "3.4.3"
+val logbackVersion = "1.5.32"
+val logstashLogbackEncoderVersion = "9.0"
+val micrometerRegistryPrometheusVersion = "1.16.5"
+val mockOAuth2ServerVersion = "3.0.1"
+val mockWebServerVersion = "5.3.2"
+val mockkVersion = "1.14.9"
+val nimbusSdkVersion = "11.37"
+val openTelemetryAnnotationsVersion = "2.27.0"
+val openTelemetryVersion = "1.61.0"
+val postgresqlVersion = "42.7.11"
 val prometheusDropWizardVersion = "0.16.0"
 val testcontainersPostgresVersion = "1.21.4"
 
@@ -31,10 +31,10 @@ val mainClassKt = "io.nais.security.oauth2.TokenExchangeAppKt"
 
 plugins {
     application
-    kotlin("jvm") version "2.2.0"
-    id("org.jmailen.kotlinter") version "5.1.1"
-    id("com.github.johnrengelman.shadow") version "8.1.1"
-    id("com.github.ben-manes.versions") version "0.52.0"
+    kotlin("jvm") version "2.3.21"
+    id("org.jmailen.kotlinter") version "5.4.2"
+    id("com.gradleup.shadow") version "9.4.1"
+    id("com.github.ben-manes.versions") version "0.54.0"
 }
 
 
@@ -58,8 +58,9 @@ repositories {
 
 configurations.all {
     resolutionStrategy {
+        // testcontainers 1.21.4 pulls commons-compress 1.24.0 (CVE-2024-25710, CVE-2024-26308).
+        // Test-only, but force a patched version to silence scanners. Re-check on testcontainers bumps.
         force("org.apache.commons:commons-compress:1.27.1")
-        force("org.apache.commons:commons-lang3:3.20.0")
     }
 }
 
@@ -140,10 +141,6 @@ tasks {
         testLogging {
             events(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
         }
-    }
-
-    "build" {
-        dependsOn("shadowJar")
     }
 
     named("dependencyUpdates", com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask::class).configure {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,6 @@ plugins {
     application
     kotlin("jvm") version "2.3.21"
     id("org.jmailen.kotlinter") version "5.4.2"
-    id("com.gradleup.shadow") version "9.4.1"
     id("com.github.ben-manes.versions") version "0.54.0"
 }
 
@@ -117,19 +116,6 @@ dependencies {
 }
 
 tasks {
-    withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
-        archiveBaseName.set("app")
-        archiveClassifier.set("")
-        manifest {
-            attributes(
-                mapOf(
-                    "Main-Class" to mainClassKt
-                )
-            )
-        }
-        mergeServiceFiles()
-    }
-
     withType<KotlinJvmCompile>().configureEach {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_21)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/TokenExchangeApp.kt
@@ -148,7 +148,7 @@ fun Application.tokenExchangeApp(
     install(ContentNegotiation) {
         jackson {
             configure(FAIL_ON_UNKNOWN_PROPERTIES, true)
-            setSerializationInclusion(NON_NULL)
+            setDefaultPropertyInclusion(NON_NULL)
         }
     }
 
@@ -219,7 +219,7 @@ internal val defaultHttpClient =
     HttpClient(CIO) {
         install(ClientContentNegotiation) {
             jackson {
-                setSerializationInclusion(NON_NULL)
+                setDefaultPropertyInclusion(NON_NULL)
                 configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
             }
         }
@@ -229,7 +229,7 @@ internal val retryingHttpClient =
     HttpClient(CIO) {
         install(ClientContentNegotiation) {
             jackson {
-                setSerializationInclusion(NON_NULL)
+                setDefaultPropertyInclusion(NON_NULL)
                 configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
             }
         }

--- a/src/main/kotlin/io/nais/security/oauth2/authentication/BearerTokenAuthenticationConfiguration.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/authentication/BearerTokenAuthenticationConfiguration.kt
@@ -7,7 +7,6 @@ import com.auth0.jwt.interfaces.JWTVerifier
 import com.nimbusds.oauth2.sdk.OAuth2Error
 import io.ktor.http.auth.HttpAuthHeader
 import io.ktor.server.auth.AuthenticationConfig
-import io.ktor.server.auth.Principal
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.jwt.jwt
 import io.nais.security.oauth2.authentication.BearerTokenAuth.CLIENT_REGISTRATION_AUTH
@@ -27,7 +26,7 @@ object BearerTokenAuth {
 data class AuthenticatedClient(
     val jwtPrincipal: JWTPrincipal,
     val provider: AuthProvider,
-) : Principal
+)
 
 fun AuthenticationConfig.clientRegistrationAuth(appConfig: AppConfiguration) {
     jwt(CLIENT_REGISTRATION_AUTH) {

--- a/src/main/kotlin/io/nais/security/oauth2/authentication/ParametersExtensions.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/authentication/ParametersExtensions.kt
@@ -19,6 +19,7 @@ fun Parameters.require(
                     ),
                 )
         }
+
         else -> {
             this[name] ?: throw OAuth2Exception(OAuth2Error.INVALID_REQUEST.setDescription("Parameter $name missing"))
         }

--- a/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestAuthorizer.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/authentication/TokenRequestAuthorizer.kt
@@ -60,6 +60,7 @@ class TokenExchangeRequestAuthorizer(
 
         return when {
             targetClient.accessPolicyInbound.contains(authenticatedClient.clientId) -> tokenRequest
+
             else -> throw OAuth2Exception(
                 OAuth2Error.INVALID_REQUEST.setDescription(
                     "client '${authenticatedClient.clientId}' is not authorized to get token with aud=${targetClient.clientId}",
@@ -88,6 +89,7 @@ class ClientCredentialsRequestAuthorizer : TokenRequestAuthorizer<OAuth2ClientCr
 
         return when {
             authenticatedClient.allowedScopes.contains(tokenRequest.scope) -> tokenRequest
+
             else -> throw OAuth2Exception(
                 OAuth2Error.INVALID_REQUEST.setDescription(
                     "client '${authenticatedClient.clientId}' is not authorized to get token with aud=${tokenRequest.scope}",

--- a/src/main/kotlin/io/nais/security/oauth2/config/EnvConfiguration.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/config/EnvConfiguration.kt
@@ -156,10 +156,12 @@ fun clientRegistrationAuthProperties(): ClientRegistrationAuthProperties {
                         log.info("loaded ${it.size} external auth providers from AUTH_PROVIDER_CONFIGS: {}", configs)
                     }
             }
+
             wellknownUrl != null -> {
                 log.info("using single external auth provider from AUTH_WELL_KNOWN_URL={} (legacy)", wellknownUrl)
                 listOf(AuthProvider.fromWellKnown(wellknownUrl))
             }
+
             else -> {
                 val selfSignedIssuer = konfig[Key(AUTH_CLIENT_ID, stringType)]
                 log.info("using self-signed auth provider with issuer=$selfSignedIssuer")

--- a/src/main/kotlin/io/nais/security/oauth2/routing/TokenExchangeApi.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/routing/TokenExchangeApi.kt
@@ -76,11 +76,14 @@ internal fun Routing.tokenExchangeApi(config: AppConfiguration) {
                         ),
                     )
                 }
-                else -> throw OAuth2Exception(
-                    OAuth2Error.INVALID_GRANT.setDescription(
-                        "grant_type=${tokenRequest.grantType} is not supported",
-                    ),
-                )
+
+                else -> {
+                    throw OAuth2Exception(
+                        OAuth2Error.INVALID_GRANT.setDescription(
+                            "grant_type=${tokenRequest.grantType} is not supported",
+                        ),
+                    )
+                }
             }
         }
     }

--- a/src/main/kotlin/io/nais/security/oauth2/token/TokenIssuer.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/token/TokenIssuer.kt
@@ -87,7 +87,10 @@ class TokenIssuer(
 
     private fun validator(issuer: String?): TokenValidator =
         when (issuer) {
-            issuerUrl -> internalTokenValidator
+            issuerUrl -> {
+                internalTokenValidator
+            }
+
             else -> {
                 issuer?.let { tokenValidators[it] }
                     ?: throw OAuth2Exception(

--- a/src/test/kotlin/io/nais/security/oauth2/config/AuthProviderAcceptHeaderTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/config/AuthProviderAcceptHeaderTest.kt
@@ -21,11 +21,12 @@ class AuthProviderAcceptHeaderTest {
             object : Dispatcher() {
                 override fun dispatch(request: RecordedRequest): MockResponse =
                     when (request.path) {
-                        "/.well-known/openid-configuration" ->
+                        "/.well-known/openid-configuration" -> {
                             MockResponse()
                                 .setBody(
                                     """{"issuer":"${server.url("/")}","jwks_uri":"${server.url("/jwks")}"}""",
                                 ).addHeader("Content-Type", "application/json")
+                        }
 
                         "/jwks" -> {
                             val accept = request.getHeader("Accept") ?: ""
@@ -40,7 +41,9 @@ class AuthProviderAcceptHeaderTest {
                             }
                         }
 
-                        else -> MockResponse().setResponseCode(404)
+                        else -> {
+                            MockResponse().setResponseCode(404)
+                        }
                     }
             }
         server.start()

--- a/src/test/kotlin/io/nais/security/oauth2/mock/MockConfiguration.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/mock/MockConfiguration.kt
@@ -45,14 +45,21 @@ fun mockConfig(
         )
     val clientRegAuthProperties =
         when {
-            clientRegistrationAuthProperties != null -> clientRegistrationAuthProperties
-            mockOAuth2Server != null ->
+            clientRegistrationAuthProperties != null -> {
+                clientRegistrationAuthProperties
+            }
+
+            mockOAuth2Server != null -> {
                 ClientRegistrationAuthProperties(
                     authProviders = listOf(AuthProvider.fromWellKnown(mockOAuth2Server.wellKnownUrl("aadmock").toString())),
                     acceptedAudience = listOf("tokendings"),
                     softwareStatementJwks = jwkSet(),
                 )
-            else -> mockBearerTokenAuthenticationProperties()
+            }
+
+            else -> {
+                mockBearerTokenAuthenticationProperties()
+            }
         }
 
     val clientRegistry = MockClientRegistry()

--- a/src/test/kotlin/io/nais/security/oauth2/mock/MockJwkerApp.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/mock/MockJwkerApp.kt
@@ -268,7 +268,7 @@ internal val httpClient =
         install(io.ktor.client.plugins.contentnegotiation.ContentNegotiation) {
             jackson {
                 configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
-                setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
             }
         }
     }

--- a/src/test/kotlin/io/nais/security/oauth2/mock/MockJwkerApp.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/mock/MockJwkerApp.kt
@@ -103,6 +103,7 @@ fun Application.mockJwkerApp() {
 
                     call.respond(statusCode, body)
                 }
+
                 else -> {
                     call.respond(HttpStatusCode.InternalServerError, error.message ?: "unknown internal server error")
                 }


### PR DESCRIPTION
Bumps dependencies and Gradle wrapper to current versions, including major bumps for Kotlin (2.2 → 2.3), Ktor (3.3 → 3.4), kotest (5 → 6), JUnit (5 → 6), HikariCP, Flyway, mock-oauth2-server, mockwebserver, and logstash-logback-encoder. Gradle wrapper goes 8.14 → 9.5.

The unmaintained johnrengelman shadow plugin is replaced with the application plugin's built-in installDist, giving better Docker layer caching and clearer SBOM scanning. Dockerfile and CI workflows are updated accordingly. Most surfaced Kotlin/Ktor deprecation warnings are also cleared. Each commit is independently buildable.