### PR TITLE
ci: bump nais/fasit-deploy to v4.0.0

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,22 +67,20 @@ jobs:
       - name: Push Chart
         run: |-
           helm push tokenx*.tgz ${{ env.FEATURE_REPOSITORY }}
-  rollout:
+  deploy:
     needs:
       - build_push_sign
     runs-on: fasit-deploy
     permissions:
       id-token: write
     steps:
-      - uses: nais/fasit-deploy@6e5772c21e82cb101537dd5e3ce78d70e2ae6402 # ratchet:nais/fasit-deploy@v3
+      - uses: nais/fasit-deploy@97187355184a7f0f4b7a36a2b49a86ce02240f7b # ratchet:nais/fasit-deploy@v4.0.0
         with:
           chart: ${{ env.FEATURE_REPOSITORY }}/tokenx
           version: ${{ needs.build_push_sign.outputs.version }}
-          target: |
-            {"kind":"tenant","tenant":"dev-nais"}
-      - uses: nais/fasit-deploy@6e5772c21e82cb101537dd5e3ce78d70e2ae6402 # ratchet:nais/fasit-deploy@v3
-        with:
-          chart: ${{ env.FEATURE_REPOSITORY }}/tokenx
-          version: ${{ needs.build_push_sign.outputs.version }}
-          target: |
-            {"kind":"tenant","tenant":"nav"}
+          targets: |
+            [
+              { "target": { "kind": "tenant", "tenant": "ci-nais" }, "wait": true },
+              { "target": { "kind": "tenant", "tenant": "dev-nais" } },
+              { "target": { "kind": "tenant", "tenant": "nav" } }
+            ]


### PR DESCRIPTION
v4 is a breaking rewrite of the action:

- Node 24 JS action (no helm/gcloud on runner)
- `target` (single object) → `targets` (JSON list of `{target, wait}` entries)
- Drops `skip-ci`, `global`, `all-environments`, `google_service_account`, `workload_identity_provider`
- Authenticates via GitHub OIDC to the new fasit deployment endpoint

Where v3 default `skip-ci: false` implicitly prepended a ci-target, the new list explicitly starts with `tenant:ci-nais` (or `management:ci-nais`) using `wait: true` before the production fan-out.

Also renames the `rollout` job to `deploy` to align with the v4 deployment-konsept.

See https://github.com/nais/fasit-deploy/releases/tag/v4.0.0 for full migration notes.