### PR TITLE
feat(token): drop sub from required claims in TokenValidator

### DIFF
--- a/src/main/kotlin/io/nais/security/oauth2/token/Extensions.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/token/Extensions.kt
@@ -15,7 +15,6 @@ import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.jwt.proc.BadJWTException
 import com.nimbusds.jwt.proc.ConfigurableJWTProcessor
-import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier
 import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import com.nimbusds.jwt.proc.JWTClaimsSetVerifier
 import com.nimbusds.oauth2.sdk.OAuth2Error
@@ -41,25 +40,6 @@ fun JWTClaimsSet.sign(rsaKey: RSAKey): SignedJWT =
     }
 
 fun SignedJWT.expiresIn(): Long = Duration.between(Instant.now(), this.jwtClaimsSet.expirationTime.toInstant()).seconds
-
-@Throws(BadJOSEException::class, JOSEException::class, BadJWTException::class)
-@WithSpan
-fun SignedJWT.verify(
-    issuer: String,
-    keySelector: JWSVerificationKeySelector<SecurityContext?>,
-): JWTClaimsSet =
-    verify(
-        DefaultJWTClaimsVerifier(
-            JWTClaimsSet
-                .Builder()
-                .issuer(issuer)
-                .build(),
-            HashSet(
-                listOf("sub", "iss", "iat", "exp"),
-            ),
-        ),
-        keySelector,
-    )
 
 @Throws(BadJOSEException::class, JOSEException::class, BadJWTException::class)
 @WithSpan

--- a/src/main/kotlin/io/nais/security/oauth2/token/TokenValidator.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/token/TokenValidator.kt
@@ -6,6 +6,7 @@ import com.nimbusds.jose.proc.JWSVerificationKeySelector
 import com.nimbusds.jose.proc.SecurityContext
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier
 import io.nais.security.oauth2.model.CacheProperties
 import io.opentelemetry.instrumentation.annotations.WithSpan
 
@@ -19,7 +20,14 @@ class TokenValidator(
     )
 
     private val keySelector = JWSVerificationKeySelector(JWSAlgorithm.RS256, jwkSource)
+    private val claimsVerifier =
+        DefaultJWTClaimsVerifier<SecurityContext>(
+            JWTClaimsSet.Builder().issuer(issuer).build(),
+            setOf("iss", "iat", "exp"),
+        )
 
     @WithSpan
-    fun validate(token: SignedJWT): JWTClaimsSet = token.verify(issuer, keySelector)
+    fun validate(token: SignedJWT): JWTClaimsSet = token.verify(claimsVerifier, keySelector)
+
+    fun maxClockSkew(): Int = claimsVerifier.maxClockSkew
 }

--- a/src/test/kotlin/io/nais/security/oauth2/token/TokenValidatorTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/token/TokenValidatorTest.kt
@@ -1,0 +1,92 @@
+package io.nais.security.oauth2.token
+
+import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.oauth2.sdk.OAuth2Error
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.nais.security.oauth2.model.OAuth2Exception
+import io.nais.security.oauth2.utils.jwkSet
+import org.junit.jupiter.api.Test
+import java.util.Date
+import java.util.concurrent.TimeUnit
+
+internal class TokenValidatorTest {
+    private val jwkSet = jwkSet()
+    private val rsaKey = jwkSet.keys.first() as RSAKey
+    private val validator = TokenValidator(ISSUER, ImmutableJWKSet(jwkSet))
+    private val beyondLeeway = TimeUnit.SECONDS.toMillis(validator.maxClockSkew().toLong()) + 1_000
+
+    @Test
+    fun `validate should succeed for valid token`() {
+        val claims = validClaims().build().sign(rsaKey)
+        val result = validator.validate(claims)
+        result.issuer shouldBe ISSUER
+        result.subject shouldBe null
+    }
+
+    @Test
+    fun `validate should reject token with wrong issuer`() {
+        val claims = validClaims().issuer("https://wrong.issuer").build().sign(rsaKey)
+        val exception = shouldThrow<OAuth2Exception> { validator.validate(claims) }
+        exception.errorObject?.code shouldBe OAuth2Error.INVALID_REQUEST.code
+        exception.errorObject?.description shouldContain "iss"
+    }
+
+    @Test
+    fun `validate should reject token with missing exp claim`() {
+        val claims =
+            JWTClaimsSet
+                .Builder()
+                .issuer(ISSUER)
+                .issueTime(Date())
+                .build()
+                .sign(rsaKey)
+        val exception = shouldThrow<OAuth2Exception> { validator.validate(claims) }
+        exception.errorObject?.code shouldBe OAuth2Error.INVALID_REQUEST.code
+        exception.errorObject?.description shouldContain "exp"
+    }
+
+    @Test
+    fun `validate should reject token with missing iat claim`() {
+        val claims =
+            JWTClaimsSet
+                .Builder()
+                .issuer(ISSUER)
+                .expirationTime(Date(System.currentTimeMillis() + beyondLeeway))
+                .build()
+                .sign(rsaKey)
+        val exception = shouldThrow<OAuth2Exception> { validator.validate(claims) }
+        exception.errorObject?.code shouldBe OAuth2Error.INVALID_REQUEST.code
+        exception.errorObject?.description shouldContain "iat"
+    }
+
+    @Test
+    fun `validate should reject expired token`() {
+        val past = Date(System.currentTimeMillis() - beyondLeeway)
+        val claims =
+            JWTClaimsSet
+                .Builder()
+                .issuer(ISSUER)
+                .issueTime(past)
+                .expirationTime(past)
+                .build()
+                .sign(rsaKey)
+        val exception = shouldThrow<OAuth2Exception> { validator.validate(claims) }
+        exception.errorObject?.code shouldBe OAuth2Error.INVALID_REQUEST.code
+        exception.errorObject?.description shouldContain "Expired+JWT"
+    }
+
+    private fun validClaims(): JWTClaimsSet.Builder =
+        JWTClaimsSet
+            .Builder()
+            .issuer(ISSUER)
+            .issueTime(Date())
+            .expirationTime(Date(System.currentTimeMillis() + beyondLeeway))
+
+    companion object {
+        private const val ISSUER = "https://test.issuer"
+    }
+}


### PR DESCRIPTION
TokenValidator is currently only used for validating subject tokens (both internal and external). Remove sub from required JWT claims to support IdPs that don't set it. Inline claim verification logic directly in TokenValidator and remove the unused extension function.

Fixes #610.