### PR TITLE
feat(token): detect and optionally reject subject token audience mismatch

### DIFF
--- a/src/main/kotlin/io/nais/security/oauth2/config/AppConfiguration.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/config/AppConfiguration.kt
@@ -123,6 +123,7 @@ class AuthorizationServerProperties(
     val tokenExpiry: Long = 300,
     val rotatingKeyStore: RotatingKeyStore,
     val clientAssertionMaxExpiry: Long = 120,
+    val validateSubjectTokenAudience: Boolean = false,
 ) {
     fun tokenEndpointUrl() = issuerUrl.path(TOKEN_PATH)
 

--- a/src/main/kotlin/io/nais/security/oauth2/config/EnvConfiguration.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/config/EnvConfiguration.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.natpryce.konfig.ConfigurationProperties
 import com.natpryce.konfig.EnvironmentVariables
 import com.natpryce.konfig.Key
+import com.natpryce.konfig.booleanType
 import com.natpryce.konfig.enumType
 import com.natpryce.konfig.intType
 import com.natpryce.konfig.listType
@@ -28,6 +29,7 @@ import io.nais.security.oauth2.config.EnvKey.ISSUER_URL
 import io.nais.security.oauth2.config.EnvKey.SUBJECT_TOKEN_ISSUERS
 import io.nais.security.oauth2.config.EnvKey.SUBJECT_TOKEN_MAPPINGS
 import io.nais.security.oauth2.config.EnvKey.TOKEN_EXPIRY_SECONDS
+import io.nais.security.oauth2.config.EnvKey.VALIDATE_SUBJECT_TOKEN_AUDIENCE
 import io.nais.security.oauth2.model.IssuerClaimMappings
 import io.nais.security.oauth2.model.issuerClaimMappingsFromJson
 import mu.KotlinLogging
@@ -66,6 +68,7 @@ internal object EnvKey {
     const val ISSUER_URL = "ISSUER_URL"
     const val SUBJECT_TOKEN_ISSUERS = "SUBJECT_TOKEN_ISSUERS"
     const val SUBJECT_TOKEN_MAPPINGS = "SUBJECT_TOKEN_MAPPINGS"
+    const val VALIDATE_SUBJECT_TOKEN_AUDIENCE = "VALIDATE_SUBJECT_TOKEN_AUDIENCE"
 }
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -95,6 +98,7 @@ object Configuration {
                         rotationInterval = Duration.ofDays(1),
                     ),
                 tokenExpiry = konfig.getOrElse(Key(TOKEN_EXPIRY_SECONDS, longType), DEFAULT_TOKEN_EXPIRY_SECONDS),
+                validateSubjectTokenAudience = konfig.getOrElse(Key(VALIDATE_SUBJECT_TOKEN_AUDIENCE, booleanType), false),
             )
         val clientRegistry = clientRegistry(databaseConfig)
         val databaseHealthCheck = databaseHealthCheck(databaseConfig)

--- a/src/main/kotlin/io/nais/security/oauth2/metrics/Metrics.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/metrics/Metrics.kt
@@ -33,4 +33,13 @@ object Metrics {
             .help("Number of tokens we have issued")
             .labelNames("client_id", "audience")
             .register()
+
+    val subjectTokenAudienceMismatchCounter: Counter =
+        Counter
+            .build()
+            .namespace(NAMESPACE)
+            .name("subject_token_audience_mismatch")
+            .help("Number of token exchanges where the internal subject token audience does not match the requesting client_id")
+            .labelNames("client_id", "subject_token_audience")
+            .register()
 }

--- a/src/main/kotlin/io/nais/security/oauth2/token/TokenIssuer.kt
+++ b/src/main/kotlin/io/nais/security/oauth2/token/TokenIssuer.kt
@@ -7,6 +7,7 @@ import com.nimbusds.oauth2.sdk.OAuth2Error
 import io.nais.security.oauth2.config.AuthorizationServerProperties
 import io.nais.security.oauth2.keystore.RotatingKeyStore
 import io.nais.security.oauth2.metrics.Metrics.issuedTokensCounter
+import io.nais.security.oauth2.metrics.Metrics.subjectTokenAudienceMismatchCounter
 import io.nais.security.oauth2.model.Claim
 import io.nais.security.oauth2.model.ClaimMappings
 import io.nais.security.oauth2.model.ClaimValueMapping
@@ -29,6 +30,7 @@ class TokenIssuer(
     private val issuerUrl: String = authorizationServerProperties.issuerUrl
     private val tokenExpiry: Long = authorizationServerProperties.tokenExpiry
     private val rotatingKeyStore: RotatingKeyStore = authorizationServerProperties.rotatingKeyStore
+    private val validateSubjectTokenAudience: Boolean = authorizationServerProperties.validateSubjectTokenAudience
 
     private val tokenValidators: Map<String, TokenValidator> =
         authorizationServerProperties.subjectTokenIssuers.associate {
@@ -57,11 +59,17 @@ class TokenIssuer(
             tryOrInvalidSubjectToken {
                 tokenExchangeRequest.subjectToken.toJwt()
             }
-        val issuer: String? = subjectTokenJwt.jwtClaimsSet.issuer
+        val subjectIssuer: String? = subjectTokenJwt.jwtClaimsSet.issuer
         val subjectTokenClaims =
             tryOrInvalidSubjectToken {
-                validator(issuer).validate(subjectTokenJwt)
+                validator(subjectIssuer).validate(subjectTokenJwt)
             }
+
+        if (subjectIssuer == issuerUrl) {
+            tryOrInvalidSubjectToken {
+                checkSubjectTokenAudience(oAuth2Client, subjectTokenClaims)
+            }
+        }
 
         val now = Instant.now()
         return JWTClaimsSet
@@ -77,7 +85,7 @@ class TokenIssuer(
                 if (!subjectTokenClaims.claims.containsKey("idp")) {
                     subjectTokenClaims.issuer?.let { claim("idp", it) }
                 }
-            }.mapSubjectTokenClaims(issuer, subjectTokenClaims)
+            }.mapSubjectTokenClaims(subjectIssuer, subjectTokenClaims)
             .build()
             .sign(rotatingKeyStore.currentSigningKey())
             .also {
@@ -142,5 +150,31 @@ class TokenIssuer(
         }
 
         return this
+    }
+
+    private fun checkSubjectTokenAudience(
+        oAuth2Client: OAuth2Client,
+        subjectTokenClaims: JWTClaimsSet,
+    ) {
+        val subjectTokenAudience = subjectTokenClaims.audience.orEmpty()
+        if (oAuth2Client.clientId in subjectTokenAudience) return
+
+        log.warn {
+            "subject token audience mismatch: client_id=${oAuth2Client.clientId} " +
+                "is not in subject token audience=$subjectTokenAudience"
+        }
+        subjectTokenAudienceMismatchCounter
+            .labels(oAuth2Client.clientId, subjectTokenAudience.joinToString(","))
+            .inc()
+
+        // TODO: this should always be validated, but is a breaking change.
+        //  Track for now and enforce by default in a future release.
+        if (validateSubjectTokenAudience) {
+            throw OAuth2Exception(
+                OAuth2Error.INVALID_REQUEST.setDescription(
+                    "audience does not match client_id=${oAuth2Client.clientId}",
+                ),
+            )
+        }
     }
 }

--- a/src/test/kotlin/io/nais/security/oauth2/token/TokenIssuerTest.kt
+++ b/src/test/kotlin/io/nais/security/oauth2/token/TokenIssuerTest.kt
@@ -1,5 +1,6 @@
 package io.nais.security.oauth2.token
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.maps.shouldContainAll
 import io.kotest.matchers.shouldBe
 import io.nais.security.oauth2.config.AuthorizationServerProperties
@@ -11,6 +12,7 @@ import io.nais.security.oauth2.mock.withMockOAuth2Server
 import io.nais.security.oauth2.model.ClaimMappings
 import io.nais.security.oauth2.model.JsonWebKeys
 import io.nais.security.oauth2.model.OAuth2Client
+import io.nais.security.oauth2.model.OAuth2Exception
 import io.nais.security.oauth2.model.OAuth2TokenExchangeRequest
 import io.nais.security.oauth2.model.SubjectTokenType
 import io.nais.security.oauth2.utils.jwkSet
@@ -294,6 +296,58 @@ internal class TokenIssuerTest {
         }
     }
 
+    @Test
+    fun `chained exchange succeeds when subject token audience matches requesting client_id`() {
+        withMockOAuth2Server {
+            val fakeKeyStore = MockRotatingKeyStore()
+            val issuer = tokenIssuer(mockOAuth2Server = this, rotatingKeyStore = fakeKeyStore)
+            val clientA = oAuth2Client("clientA")
+            val clientB = oAuth2Client("clientB")
+
+            val externalSubjectToken = createSubjectToken("thesubject").serialize()
+            val internalToken = issuer.issueTokenFor(clientA, tokenExchangeRequest(externalSubjectToken, "clientB"))
+
+            // clientB exchanges the token issued to it — audience matches
+            val result = issuer.issueTokenFor(clientB, tokenExchangeRequest(internalToken.serialize(), "someTarget"))
+            result.verifySignature(issuer.publicJwkSet()).claims["sub"] shouldBe "thesubject"
+        }
+    }
+
+    @Test
+    fun `chained exchange succeeds with audience mismatch when validation is disabled (default)`() {
+        withMockOAuth2Server {
+            val fakeKeyStore = MockRotatingKeyStore()
+            val issuer = tokenIssuer(mockOAuth2Server = this, rotatingKeyStore = fakeKeyStore, validateSubjectTokenAudience = false)
+            val clientA = oAuth2Client("clientA")
+            val clientC = oAuth2Client("clientC")
+
+            val externalSubjectToken = createSubjectToken("thesubject").serialize()
+            val internalToken = issuer.issueTokenFor(clientA, tokenExchangeRequest(externalSubjectToken, "clientB"))
+
+            // clientC exchanges a token issued to clientB — mismatch, but validation is off
+            val result = issuer.issueTokenFor(clientC, tokenExchangeRequest(internalToken.serialize(), "someTarget"))
+            result.verifySignature(issuer.publicJwkSet()).claims["sub"] shouldBe "thesubject"
+        }
+    }
+
+    @Test
+    fun `chained exchange fails with audience mismatch when validation is enabled`() {
+        withMockOAuth2Server {
+            val fakeKeyStore = MockRotatingKeyStore()
+            val issuer = tokenIssuer(mockOAuth2Server = this, rotatingKeyStore = fakeKeyStore, validateSubjectTokenAudience = true)
+            val clientA = oAuth2Client("clientA")
+            val clientC = oAuth2Client("clientC")
+
+            val externalSubjectToken = createSubjectToken("thesubject").serialize()
+            val internalToken = issuer.issueTokenFor(clientA, tokenExchangeRequest(externalSubjectToken, "clientB"))
+
+            // clientC exchanges a token issued to clientB — mismatch, validation is on
+            shouldThrow<OAuth2Exception> {
+                issuer.issueTokenFor(clientC, tokenExchangeRequest(internalToken.serialize(), "someTarget"))
+            }
+        }
+    }
+
     private fun MockOAuth2Server.createSubjectToken(
         subject: String,
         claims: Map<String, Any> = emptyMap(),
@@ -317,9 +371,9 @@ internal class TokenIssuerTest {
         audience,
     )
 
-    private fun oAuth2Client(): OAuth2Client =
+    private fun oAuth2Client(clientId: String = "testclient"): OAuth2Client =
         OAuth2Client(
-            "testclient",
+            clientId,
             JsonWebKeys(jwkSet()),
         )
 
@@ -327,6 +381,7 @@ internal class TokenIssuerTest {
         mockOAuth2Server: MockOAuth2Server? = null,
         rotatingKeyStore: RotatingKeyStore? = null,
         subjectTokenMappings: ClaimMappings = emptyMap(),
+        validateSubjectTokenAudience: Boolean = false,
     ) = if (mockOAuth2Server != null) {
         TokenIssuer(
             AuthorizationServerProperties(
@@ -338,6 +393,7 @@ internal class TokenIssuerTest {
                     ),
                 tokenExpiry = 300,
                 rotatingKeyStore = rotatingKeyStore ?: rotatingKeyStore(),
+                validateSubjectTokenAudience = validateSubjectTokenAudience,
             ),
         )
     } else {
@@ -347,6 +403,7 @@ internal class TokenIssuerTest {
                 subjectTokenIssuers = emptyList(),
                 tokenExpiry = 300,
                 rotatingKeyStore = rotatingKeyStore ?: rotatingKeyStore(),
+                validateSubjectTokenAudience = validateSubjectTokenAudience,
             ),
         )
     }


### PR DESCRIPTION
Track when clients re-exchange internally-issued tokens not addressed to them via metric and log warning. Add `VALIDATE_SUBJECT_TOKEN_AUDIENCE` env var to opt-in to rejecting mismatches (breaking change when enabled).